### PR TITLE
Updated model and dependencies; Initial implementation of all handlers except ListHandler

### DIFF
--- a/aws-ssm-association/.rpdk-config
+++ b/aws-ssm-association/.rpdk-config
@@ -3,5 +3,12 @@
     "language": "java",
     "runtime": "java8",
     "entrypoint": "com.aws.ssm.association.HandlerWrapper::handleRequest",
-    "settings": {}
+    "settings": {
+        "namespace": [
+            "com",
+            "aws",
+            "ssm",
+            "association"
+        ]
+    }
 }

--- a/aws-ssm-association/aws-ssm-association.json
+++ b/aws-ssm-association/aws-ssm-association.json
@@ -1,8 +1,60 @@
 {
     "typeName": "AWS::SSM::Association",
-    "description": "Resource Schema For AWS::SSM::Association",
-    "sourceUrl": "git@github.com:aws-cloudformation/aws-cloudformation-resource-providers-ssm.git",
+    "description": "The AWS::SSM::Association resource associates an SSM document in AWS Systems Manager with EC2 instances that contain a configuration agent to process the document.",
+    "sourceUrl": "https://github.com/awslabs/aws-cloudformation-rpdk.git",
     "definitions": {
+        "Target": {
+            "type": "object",
+            "properties": {
+                "Key": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "pattern": "^[\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*$"
+                },
+                "Values": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 0,
+                    "maxItems": 50
+                }
+            },
+            "required": [
+                "Key",
+                "Values"
+            ]
+        },
+        "S3Region": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 20
+        },
+        "S3BucketName": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63
+        },
+        "S3KeyPrefix": {
+            "type": "string",
+            "maxLength": 1024
+        },
+        "S3OutputLocation": {
+            "type": "object",
+            "properties": {
+                "OutputS3Region": {
+                    "$ref": "#/definitions/S3Region"
+                },
+                "OutputS3BucketName": {
+                    "$ref": "#/definitions/S3BucketName"
+                },
+                "OutputS3KeyPrefix": {
+                    "$ref": "#/definitions/S3KeyPrefix"
+                }
+            },
+            "additionalProperties": false
+        },
         "InstanceAssociationOutputLocation": {
             "type": "object",
             "properties": {
@@ -10,128 +62,135 @@
                     "$ref": "#/definitions/S3OutputLocation"
                 }
             }
-        },
-        "S3OutputLocation": {
-            "type": "object",
-            "properties": {
-                "OutputS3BucketName": {
-                    "type": "string",
-                    "minLength": 3,
-                    "maxLength": 63
-                },
-                "OutputS3KeyPrefix": {
-                    "type": "string",
-                    "maxLength": 500
-                }
-            }
-        },
-        "Parameters": {
-            "type": "object",
-            "patternProperties": {
-                "^S_": {
-                    "$ref": "#/definitions/ParameterValues"
-                }
-            }
-        },
-        "ParameterValues": {
-            "type": "object",
-            "properties": {
-                "ParameterValues": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "Targets": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/Target"
-            }
-        },
-        "Target": {
-            "type": "object",
-            "properties": {
-                "Key": {
-                    "type": "string"
-                },
-                "Values": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            },
-            "required": [
-                "Key",
-                "Values"
-            ]
         }
     },
     "properties": {
         "AssociationId": {
-            "type": "string"
+            "description": "Unique identifier of the association.",
+            "type": "string",
+            "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
         },
         "AssociationName": {
+            "description": "The name of the association.",
             "type": "string",
             "pattern": "^[a-zA-Z0-9_\\-.]{3,128}$"
         },
         "DocumentVersion": {
-            "type": "string"
+            "description": "The version of the SSM document to associate with the target.",
+            "type": "string",
+            "pattern": "([$]LATEST|[$]DEFAULT|^[1-9][0-9]*$)"
         },
         "InstanceId": {
+            "description": "The ID of the instance that the SSM document is associated with.",
             "type": "string",
             "pattern": "(^i-(\\w{8}|\\w{17})$)|(^mi-\\w{17}$)"
         },
         "Name": {
+            "description": "The name of the SSM document.",
             "type": "string",
-            "pattern": "^[a-zA-Z0-9_\\-.:/]{3,128}$"
-        },
-        "OutputLocation": {
-            "$ref": "#/definitions/InstanceAssociationOutputLocation"
+            "maxLength": 200,
+            "pattern": "^[a-zA-Z0-9_\\-.:/]{3,200}$"
         },
         "Parameters": {
-            "$ref": "#/definitions/Parameters"
+            "description": "Parameter values that the SSM document uses at runtime.",
+            "type": "object",
+            "patternProperties": {
+                ".*{1,255}": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 65535
+                    }
+                }
+            },
+            "additionalProperties": false
         },
         "ScheduleExpression": {
+            "description": "A Cron expression that specifies when the association is applied to the target.",
             "type": "string",
             "minLength": 1,
             "maxLength": 256
         },
         "Targets": {
-            "$ref": "#/definitions/Targets",
+            "description": "The targets that the SSM document sends commands to.",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/Target"
+            },
+            "minItems": 0,
             "maxItems": 5
-        }
-    },
-    "oneOf": [
-        {
-            "required": [
-                "#/properties/Name",
-                "#/properties/InstanceId"
+        },
+        "OutputLocation": {
+            "$ref": "#/definitions/InstanceAssociationOutputLocation"
+        },
+        "AutomationTargetParameterName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+        },
+        "MaxErrors": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 7,
+            "pattern": "^([1-9][0-9]*|[0]|[1-9][0-9]%|[0-9]%|100%)$"
+        },
+        "MaxConcurrency": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 7,
+            "pattern": "^([1-9][0-9]*|[1-9][0-9]%|[1-9]%|100%)$"
+        },
+        "ComplianceSeverity": {
+            "type": "string",
+            "enum": [
+                "CRITICAL",
+                "HIGH",
+                "MEDIUM",
+                "LOW",
+                "UNSPECIFIED"
             ]
         },
-        {
-            "required": [
-                "#/properties/Name",
-                "#/properties/Targets"
-            ]
+        "WaitForAssociationSuccess": {
+            "type": "boolean"
         }
-    ],
-    "createOnlyProperties": [
-        "/properties/InstanceId",
-        "/properties/Name",
-        "/properties/Targets"
+    },
+    "required": [
+        "Name"
     ],
     "readOnlyProperties": [
         "/properties/AssociationId"
     ],
-    "identifiers": [
-        [
-            "#/properties/AssociationId"
-        ],
-        [
-            "#/properties/Name"
-        ]
-    ]
+    "primaryIdentifier": [
+        "/properties/AssociationId"
+    ],
+    "handlers": {
+        "create": {
+            "permissions": [
+                "ssm:CreateAssociation",
+                "ssm:DescribeAssociation"
+            ]
+        },
+        "delete": {
+            "permissions": [
+                "ssm:DeleteAssociation"
+            ]
+        },
+        "update": {
+            "permissions": [
+                "ssm:UpdateAssociation"
+            ]
+        },
+        "list": {
+            "permissions": [
+                "ssm:ListAssociations",
+                "ssm:DescribeAssociation"
+            ]
+        },
+        "read": {
+            "permissions": [
+                "ssm:DescribeAssociation"
+            ]
+        }
+    }
 }

--- a/aws-ssm-association/pom.xml
+++ b/aws-ssm-association/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.aws.ssm.association</groupId>
@@ -26,6 +26,13 @@
     </repositories>
 
     <dependencies>
+        <!-- Custom dependencies -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-ssm</artifactId>
+            <version>1.11.517</version>
+        </dependency>
+
         <!-- https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/ -->
         <dependency>
             <groupId>com.amazonaws.cloudformation</groupId>
@@ -155,6 +162,7 @@
                         <exclude>**/BaseConfiguration*</exclude>
                         <exclude>**/BaseHandler*</exclude>
                         <exclude>**/HandlerWrapper*</exclude>
+                        <exclude>**/ResourceModel*</exclude>
                     </excludes>
                 </configuration>
                 <executions>
@@ -182,11 +190,6 @@
                                     <limits>
                                         <limit>
                                             <counter>BRANCH</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.8</minimum>
-                                        </limit>
-                                        <limit>
-                                            <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
                                             <minimum>0.8</minimum>
                                         </limit>

--- a/aws-ssm-association/src/main/java/com/aws/ssm/association/CallbackContext.java
+++ b/aws-ssm-association/src/main/java/com/aws/ssm/association/CallbackContext.java
@@ -1,12 +1,16 @@
 package com.aws.ssm.association;
 
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDescription;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class CallbackContext {
-
+    private Integer stabilizationRetriesRemaining;
+    private AssociationDescription associationDescription;
 }

--- a/aws-ssm-association/src/main/java/com/aws/ssm/association/Configuration.java
+++ b/aws-ssm-association/src/main/java/com/aws/ssm/association/Configuration.java
@@ -1,6 +1,7 @@
 package com.aws.ssm.association;
 
-import java.io.InputStream;
+import org.json.JSONObject;
+import org.json.JSONTokener;
 
 class Configuration extends BaseConfiguration {
 
@@ -8,8 +9,8 @@ class Configuration extends BaseConfiguration {
         super("aws-ssm-association.json");
     }
 
-    public InputStream resourceSchema() {
-        return this.getClass().getClassLoader().getResourceAsStream(schemaFilename);
+    public JSONObject resourceSchemaJSONObject() {
+        return new JSONObject(new JSONTokener(this.getClass().getClassLoader().getResourceAsStream(schemaFilename)));
     }
 
 }

--- a/aws-ssm-association/src/main/java/com/aws/ssm/association/CreateHandler.java
+++ b/aws-ssm-association/src/main/java/com/aws/ssm/association/CreateHandler.java
@@ -1,12 +1,47 @@
 package com.aws.ssm.association;
 
+import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
+import com.amazonaws.cloudformation.proxy.HandlerErrorCode;
 import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
+import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationAlreadyExistsException;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDescription;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDoesNotExistException;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationLimitExceededException;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationStatusName;
+import com.amazonaws.services.simplesystemsmanagement.model.CreateAssociationRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.DescribeAssociationRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.InternalServerErrorException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidAssociationVersionException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidDocumentException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidDocumentVersionException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidInstanceIdException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidOutputLocationException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidParametersException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidScheduleException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidTargetException;
+import com.amazonaws.services.simplesystemsmanagement.model.UnsupportedPlatformTypeException;
+import com.amazonaws.util.StringUtils;
+import com.aws.ssm.association.util.ResourceModelServiceModelConverter;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class CreateHandler extends BaseHandler<CallbackContext> {
+
+    private static final int CALLBACK_DELAY_SECONDS = 15;
+    private static final int NUM_STABILIZATION_RETRIES = 10;
+    private static final AWSSimpleSystemsManagement SSM_CLIENT =
+        AWSSimpleSystemsManagementClientBuilder.standard()
+            .withClientConfiguration(new ClientConfigurationFactory().getConfig())
+            .build();
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -15,13 +50,230 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         final CallbackContext callbackContext,
         final Logger logger) {
 
-        final ResourceModel model = request.getDesiredResourceState();
+        if (callbackContext != null) {
+            return handleInProgressCreateRequest(proxy, logger, callbackContext);
+        } else {
+            return handleInitialCreateRequest(proxy, logger, request.getDesiredResourceState());
+        }
+    }
 
-        // TODO : put your code here
+    private ProgressEvent<ResourceModel, CallbackContext> handleInitialCreateRequest(
+        final AmazonWebServicesClientProxy proxy,
+        final Logger logger,
+        final ResourceModel desiredModel) {
 
-        return ProgressEvent.<ResourceModel, CallbackContext>builder()
-            .resourceModel(model)
-            .status(OperationStatus.SUCCESS)
-            .build();
+        if (StringUtils.isNullOrEmpty(desiredModel.getName())) {
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .status(OperationStatus.FAILED)
+                .errorCode(HandlerErrorCode.InvalidRequest)
+                .message("Document name must be specified to create an association.")
+                .build();
+        }
+
+        final CreateAssociationRequest createAssociationRequest = resourceModelToCreateAssociationRequest(desiredModel);
+
+        final AssociationDescription resultAssociationDescription;
+
+        try {
+            resultAssociationDescription =
+                proxy.injectCredentialsAndInvoke(createAssociationRequest, SSM_CLIENT::createAssociation)
+                    .getAssociationDescription();
+        } catch (AssociationAlreadyExistsException e) {
+            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.AlreadyExists);
+        } catch (AssociationLimitExceededException e) {
+            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.ServiceLimitExceeded);
+        } catch (InvalidDocumentException
+            | InvalidDocumentVersionException
+            | InvalidInstanceIdException
+            | UnsupportedPlatformTypeException
+            | InvalidOutputLocationException
+            | InvalidParametersException
+            | InvalidTargetException
+            | InvalidScheduleException e) {
+
+            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.InvalidRequest);
+        } catch (InternalServerErrorException e) {
+            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.ServiceInternalError);
+        } catch (Exception e) {
+            logger.log(e.getMessage());
+
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .status(OperationStatus.FAILED)
+                .errorCode(HandlerErrorCode.GeneralServiceException)
+                .message("Unknown failure occurred.")
+                .build();
+        }
+
+        final ResourceModel resultModel =
+            ResourceModelServiceModelConverter.associationDescriptionToResourceModel(resultAssociationDescription);
+
+        if (desiredModel.getWaitForAssociationSuccess() != null
+            && desiredModel.getWaitForAssociationSuccess()) {
+            // indicates a Create request that needs to wait for association to complete
+            return ProgressEvent.defaultInProgressHandler(
+                CallbackContext.builder()
+                    .stabilizationRetriesRemaining(NUM_STABILIZATION_RETRIES)
+                    .associationDescription(resultAssociationDescription)
+                    .build(),
+                CALLBACK_DELAY_SECONDS,
+                resultModel);
+        } else {
+            // return success without waiting for association to complete
+            return ProgressEvent.defaultSuccessHandler(resultModel);
+        }
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> handleInProgressCreateRequest(
+        final AmazonWebServicesClientProxy proxy,
+        final Logger logger,
+        final CallbackContext callbackContext) {
+
+        final AssociationDescription callbackContextAssociation = callbackContext.getAssociationDescription();
+
+        final DescribeAssociationRequest describeAssociationRequest =
+            new DescribeAssociationRequest()
+                .withAssociationId(callbackContextAssociation.getAssociationId());
+
+        final AssociationDescription requestAssociation;
+
+        try {
+            requestAssociation =
+                proxy.injectCredentialsAndInvoke(describeAssociationRequest, SSM_CLIENT::describeAssociation)
+                    .getAssociationDescription();
+
+        } catch (AssociationDoesNotExistException e) {
+            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.NotFound);
+        } catch (InvalidAssociationVersionException
+            | InvalidDocumentException
+            | InvalidInstanceIdException e) {
+
+            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.InvalidRequest);
+        } catch (InternalServerErrorException e) {
+            return ProgressEvent.defaultFailureHandler(e, HandlerErrorCode.ServiceInternalError);
+        } catch (Exception e) {
+            logger.log(e.getMessage());
+
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .status(OperationStatus.FAILED)
+                .errorCode(HandlerErrorCode.GeneralServiceException)
+                .message("Unknown failure occurred.")
+                .build();
+        }
+
+        final ResourceModel existingModel =
+            ResourceModelServiceModelConverter.associationDescriptionToResourceModel(requestAssociation);
+
+        if (AssociationStatusName.Success.name()
+            .equalsIgnoreCase(requestAssociation.getOverview().getStatus())) {
+
+            return ProgressEvent.defaultSuccessHandler(existingModel);
+
+        } else if (AssociationStatusName.Pending.name()
+            .equalsIgnoreCase(requestAssociation.getOverview().getStatus())) {
+
+            final int stabilizationRetriesRemaining = callbackContext.getStabilizationRetriesRemaining() - 1;
+
+            if (stabilizationRetriesRemaining < 1) {
+                return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .status(OperationStatus.FAILED)
+                    .errorCode(HandlerErrorCode.NotStabilized)
+                    .message("Timed out waiting for association to succeed.")
+                    .build();
+            }
+
+            return ProgressEvent.defaultInProgressHandler(
+                CallbackContext.builder()
+                    .stabilizationRetriesRemaining(stabilizationRetriesRemaining)
+                    .associationDescription(requestAssociation)
+                    .build(),
+                CALLBACK_DELAY_SECONDS,
+                existingModel);
+
+        } else {
+
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .status(OperationStatus.FAILED)
+                .errorCode(HandlerErrorCode.NotStabilized)
+                .message(String.format(
+                    "Association failed; detailed status: %s",
+                    requestAssociation.getOverview().getDetailedStatus()))
+                .build();
+        }
+    }
+
+    private CreateAssociationRequest resourceModelToCreateAssociationRequest(final ResourceModel model) {
+
+        final CreateAssociationRequest createAssociationRequest =
+            new CreateAssociationRequest()
+                .withName(model.getName());
+
+        if (!StringUtils.isNullOrEmpty(model.getAssociationName())) {
+            createAssociationRequest.setAssociationName(model.getAssociationName());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getDocumentVersion())) {
+            createAssociationRequest.setDocumentVersion(model.getDocumentVersion());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getInstanceId())) {
+            createAssociationRequest.setInstanceId(model.getInstanceId());
+        }
+
+        if (MapUtils.isNotEmpty(model.getParameters())) {
+            createAssociationRequest.setParameters(model.getParameters());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getScheduleExpression())) {
+            createAssociationRequest.setScheduleExpression(model.getScheduleExpression());
+        }
+
+        if (CollectionUtils.isNotEmpty(model.getTargets())) {
+            final List<com.amazonaws.services.simplesystemsmanagement.model.Target> convertedTargets =
+                model.getTargets().stream()
+                    .map(t -> new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(t.getKey())
+                        .withValues(t.getValues()))
+                    .collect(Collectors.toList());
+
+            createAssociationRequest.setTargets(convertedTargets);
+        }
+
+        final InstanceAssociationOutputLocation resourceModelOutputLocation = model.getOutputLocation();
+
+        if (resourceModelOutputLocation != null
+            && resourceModelOutputLocation.getS3Location() != null) {
+
+            final S3OutputLocation s3Location = resourceModelOutputLocation.getS3Location();
+
+            com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation serviceModelS3Location =
+                new com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation()
+                    .withOutputS3BucketName(s3Location.getOutputS3BucketName())
+                    .withOutputS3Region(s3Location.getOutputS3Region())
+                    .withOutputS3KeyPrefix(s3Location.getOutputS3KeyPrefix());
+
+            com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation serviceModelOutputLocation =
+                new com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation()
+                    .withS3Location(serviceModelS3Location);
+
+            createAssociationRequest.setOutputLocation(serviceModelOutputLocation);
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getAutomationTargetParameterName())) {
+            createAssociationRequest.setAutomationTargetParameterName(model.getAutomationTargetParameterName());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getMaxErrors())) {
+            createAssociationRequest.setMaxErrors(model.getMaxErrors());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getMaxConcurrency())) {
+            createAssociationRequest.setMaxConcurrency(model.getMaxConcurrency());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getComplianceSeverity())) {
+            createAssociationRequest.setComplianceSeverity(model.getComplianceSeverity());
+        }
+
+        return createAssociationRequest;
     }
 }

--- a/aws-ssm-association/src/main/java/com/aws/ssm/association/DeleteHandler.java
+++ b/aws-ssm-association/src/main/java/com/aws/ssm/association/DeleteHandler.java
@@ -1,10 +1,21 @@
 package com.aws.ssm.association;
 
+import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
+import com.amazonaws.cloudformation.proxy.HandlerErrorCode;
 import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
+import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDoesNotExistException;
+import com.amazonaws.services.simplesystemsmanagement.model.DeleteAssociationRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.InternalServerErrorException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidDocumentException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidInstanceIdException;
+import com.amazonaws.services.simplesystemsmanagement.model.TooManyUpdatesException;
+import com.amazonaws.util.StringUtils;
 
 public class DeleteHandler extends BaseHandler<CallbackContext> {
 
@@ -16,12 +27,64 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
         final Logger logger) {
 
         final ResourceModel model = request.getDesiredResourceState();
+        final ProgressEvent<ResourceModel, CallbackContext> pe =
+            ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModel(model)
+                .build();
 
-        // TODO : put your code here
+        pe.setStatus(OperationStatus.FAILED);
 
-        return ProgressEvent.<ResourceModel, CallbackContext>builder()
-            .resourceModel(model)
-            .status(OperationStatus.SUCCESS)
-            .build();
+        DeleteAssociationRequest deleteAssociationRequest = new DeleteAssociationRequest();
+
+        if (!StringUtils.isNullOrEmpty(model.getAssociationId())) {
+
+            deleteAssociationRequest.setAssociationId(model.getAssociationId());
+
+        } else if (!StringUtils.isNullOrEmpty(model.getInstanceId())
+            && !StringUtils.isNullOrEmpty(model.getName())) {
+
+            deleteAssociationRequest
+                .withInstanceId(model.getInstanceId())
+                .setName(model.getName());
+        } else {
+            // fails delete request validation
+            pe.setErrorCode(HandlerErrorCode.InvalidRequest);
+            pe.setMessage("AssociationId, or InstanceId and Document Name must be specified to delete an association.");
+            return pe;
+        }
+
+        final AWSSimpleSystemsManagement client =
+            AWSSimpleSystemsManagementClientBuilder.standard()
+                .withClientConfiguration(new ClientConfigurationFactory().getConfig())
+                .build();
+
+        try {
+            proxy.injectCredentialsAndInvoke(deleteAssociationRequest, client::deleteAssociation);
+            pe.setStatus(OperationStatus.SUCCESS);
+        } catch (AssociationDoesNotExistException e) {
+            pe.setStatus(OperationStatus.SUCCESS);
+        } catch (TooManyUpdatesException e) {
+            pe.setErrorCode(HandlerErrorCode.Throttling);
+            pe.setMessage(e.getMessage());
+        } catch (InvalidDocumentException
+            | InvalidInstanceIdException e) {
+            pe.setErrorCode(HandlerErrorCode.InvalidRequest);
+            pe.setMessage(e.getMessage());
+        } catch (InternalServerErrorException e) {
+            pe.setErrorCode(HandlerErrorCode.ServiceInternalError);
+            pe.setMessage(e.getMessage());
+        } catch (Exception e) {
+            logger.log(e.getMessage());
+
+            pe.setErrorCode(HandlerErrorCode.GeneralServiceException);
+            pe.setMessage("Unknown failure occurred.");
+        }
+
+        if (pe.isSuccess()) {
+            // nullify the model if delete succeeded
+            pe.setResourceModel(null);
+        }
+
+        return pe;
     }
 }

--- a/aws-ssm-association/src/main/java/com/aws/ssm/association/ListHandler.java
+++ b/aws-ssm-association/src/main/java/com/aws/ssm/association/ListHandler.java
@@ -2,8 +2,8 @@ package com.aws.ssm.association;
 
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
 import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
+import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.ArrayList;

--- a/aws-ssm-association/src/main/java/com/aws/ssm/association/ReadHandler.java
+++ b/aws-ssm-association/src/main/java/com/aws/ssm/association/ReadHandler.java
@@ -1,10 +1,23 @@
 package com.aws.ssm.association;
 
+import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
+import com.amazonaws.cloudformation.proxy.HandlerErrorCode;
 import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
+import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDescription;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDoesNotExistException;
+import com.amazonaws.services.simplesystemsmanagement.model.DescribeAssociationRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.InternalServerErrorException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidAssociationVersionException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidDocumentException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidInstanceIdException;
+import com.amazonaws.util.StringUtils;
+import com.aws.ssm.association.util.ResourceModelServiceModelConverter;
 
 public class ReadHandler extends BaseHandler<CallbackContext> {
 
@@ -15,13 +28,59 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
         final CallbackContext callbackContext,
         final Logger logger) {
 
-        final ResourceModel model = request.getDesiredResourceState();
+        logger.log(String.format("Processing ReadHandler request %s", request));
 
-        // TODO : put your code here
+        final ResourceModel requestModel = request.getDesiredResourceState();
 
-        return ProgressEvent.<ResourceModel, CallbackContext>builder()
-            .resourceModel(model)
-            .status(OperationStatus.SUCCESS)
-            .build();
+        final ProgressEvent<ResourceModel, CallbackContext> pe = new ProgressEvent<>();
+        pe.setStatus(OperationStatus.FAILED);
+
+        final String associationId = requestModel.getAssociationId();
+
+        if (StringUtils.isNullOrEmpty(associationId)) {
+            pe.setErrorCode(HandlerErrorCode.InvalidRequest);
+            pe.setMessage("AssociationId must be present to read the existing association.");
+            return pe;
+        }
+
+        final AWSSimpleSystemsManagement client =
+            AWSSimpleSystemsManagementClientBuilder.standard()
+                .withClientConfiguration(new ClientConfigurationFactory().getConfig())
+                .build();
+
+        final DescribeAssociationRequest describeAssociationRequest =
+            new DescribeAssociationRequest()
+                .withAssociationId(associationId);
+
+        try {
+            final AssociationDescription association =
+                proxy.injectCredentialsAndInvoke(describeAssociationRequest, client::describeAssociation)
+                    .getAssociationDescription();
+
+            final ResourceModel existingModel =
+                ResourceModelServiceModelConverter.associationDescriptionToResourceModel(association);
+
+            pe.setResourceModel(existingModel);
+            pe.setStatus(OperationStatus.SUCCESS);
+
+        } catch (AssociationDoesNotExistException e) {
+            pe.setErrorCode(HandlerErrorCode.NotFound);
+            pe.setMessage(e.getMessage());
+        } catch (InvalidAssociationVersionException
+            | InvalidDocumentException
+            | InvalidInstanceIdException e) {
+            pe.setErrorCode(HandlerErrorCode.InvalidRequest);
+            pe.setMessage(e.getMessage());
+        } catch (InternalServerErrorException e) {
+            pe.setErrorCode(HandlerErrorCode.ServiceInternalError);
+            pe.setMessage(e.getMessage());
+        } catch (Exception e) {
+            logger.log(e.getMessage());
+
+            pe.setErrorCode(HandlerErrorCode.GeneralServiceException);
+            pe.setMessage("Unknown failure occurred.");
+        }
+
+        return pe;
     }
 }

--- a/aws-ssm-association/src/main/java/com/aws/ssm/association/UpdateHandler.java
+++ b/aws-ssm-association/src/main/java/com/aws/ssm/association/UpdateHandler.java
@@ -1,10 +1,36 @@
 package com.aws.ssm.association;
 
+import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
+import com.amazonaws.cloudformation.proxy.HandlerErrorCode;
 import com.amazonaws.cloudformation.proxy.Logger;
-import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
+import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDescription;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDoesNotExistException;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationVersionLimitExceededException;
+import com.amazonaws.services.simplesystemsmanagement.model.InternalServerErrorException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidAssociationVersionException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidDocumentException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidDocumentVersionException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidOutputLocationException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidParametersException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidScheduleException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidTargetException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidUpdateException;
+import com.amazonaws.services.simplesystemsmanagement.model.Target;
+import com.amazonaws.services.simplesystemsmanagement.model.TooManyUpdatesException;
+import com.amazonaws.services.simplesystemsmanagement.model.UpdateAssociationRequest;
+import com.amazonaws.util.StringUtils;
+import com.aws.ssm.association.util.ResourceModelServiceModelConverter;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class UpdateHandler extends BaseHandler<CallbackContext> {
 
@@ -15,13 +41,147 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         final CallbackContext callbackContext,
         final Logger logger) {
 
-        final ResourceModel model = request.getDesiredResourceState();
+        logger.log(String.format("Processing UpdateHandler request %s", request));
 
-        // TODO : put your code here
+        final ResourceModel requestModel = request.getDesiredResourceState();
 
-        return ProgressEvent.<ResourceModel, CallbackContext>builder()
-            .resourceModel(model)
-            .status(OperationStatus.SUCCESS)
-            .build();
+        final ProgressEvent<ResourceModel, CallbackContext> pe = new ProgressEvent<>();
+        pe.setResourceModel(request.getPreviousResourceState());
+        pe.setStatus(OperationStatus.FAILED);
+
+        final String associationId = requestModel.getAssociationId();
+
+        if (StringUtils.isNullOrEmpty(associationId)) {
+            pe.setErrorCode(HandlerErrorCode.InvalidRequest);
+            pe.setMessage("AssociationId must be present to update the existing association.");
+            return pe;
+        }
+
+        final UpdateAssociationRequest updateAssociationRequest =
+            resourceModelToUpdateAssociationRequest(requestModel);
+
+        final AWSSimpleSystemsManagement client =
+            AWSSimpleSystemsManagementClientBuilder.standard()
+                .withClientConfiguration(new ClientConfigurationFactory().getConfig())
+                .build();
+
+        try {
+            final AssociationDescription association =
+                proxy.injectCredentialsAndInvoke(updateAssociationRequest, client::updateAssociation)
+                    .getAssociationDescription();
+
+            final ResourceModel updatedModel =
+                ResourceModelServiceModelConverter.associationDescriptionToResourceModel(association);
+
+            pe.setResourceModel(updatedModel);
+            pe.setStatus(OperationStatus.SUCCESS);
+
+        } catch (AssociationDoesNotExistException e) {
+            pe.setErrorCode(HandlerErrorCode.NotFound);
+            pe.setMessage(e.getMessage());
+        } catch (InvalidScheduleException
+            | InvalidParametersException
+            | InvalidOutputLocationException
+            | InvalidDocumentVersionException
+            | InvalidDocumentException
+            | InvalidTargetException
+            | InvalidAssociationVersionException e) {
+            pe.setErrorCode(HandlerErrorCode.InvalidRequest);
+            pe.setMessage(e.getMessage());
+        } catch (InvalidUpdateException e) {
+            pe.setErrorCode(HandlerErrorCode.NotUpdatable);
+            pe.setMessage(e.getMessage());
+        } catch (TooManyUpdatesException e) {
+            pe.setErrorCode(HandlerErrorCode.Throttling);
+            pe.setMessage(e.getMessage());
+        } catch (AssociationVersionLimitExceededException e) {
+            pe.setErrorCode(HandlerErrorCode.ServiceLimitExceeded);
+            pe.setMessage(e.getMessage());
+        } catch (InternalServerErrorException e) {
+            pe.setErrorCode(HandlerErrorCode.ServiceInternalError);
+            pe.setMessage(e.getMessage());
+        } catch (Exception e) {
+            logger.log(e.getMessage());
+
+            pe.setErrorCode(HandlerErrorCode.GeneralServiceException);
+            pe.setMessage("Unknown failure occurred.");
+        }
+
+        return pe;
+    }
+
+    private UpdateAssociationRequest resourceModelToUpdateAssociationRequest(final ResourceModel model) {
+
+        final UpdateAssociationRequest updateAssociationRequest =
+            new UpdateAssociationRequest()
+                .withAssociationId(model.getAssociationId());
+
+        if (!StringUtils.isNullOrEmpty(model.getName())) {
+            updateAssociationRequest.setName(model.getName());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getAssociationName())) {
+            updateAssociationRequest.setAssociationName(model.getAssociationName());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getDocumentVersion())) {
+            updateAssociationRequest.setDocumentVersion(model.getDocumentVersion());
+        }
+
+        if (MapUtils.isNotEmpty(model.getParameters())) {
+            updateAssociationRequest.setParameters(model.getParameters());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getScheduleExpression())) {
+            updateAssociationRequest.setScheduleExpression(model.getScheduleExpression());
+        }
+
+        if (CollectionUtils.isNotEmpty(model.getTargets())) {
+            final List<Target> convertedTargets =
+                model.getTargets().stream()
+                    .map(t -> new Target().withKey(t.getKey()).withValues(t.getValues()))
+                    .collect(Collectors.toList());
+
+            updateAssociationRequest.setTargets(convertedTargets);
+        }
+
+        final InstanceAssociationOutputLocation resourceModelOutputLocation =
+            model.getOutputLocation();
+
+        if (resourceModelOutputLocation != null
+            && resourceModelOutputLocation.getS3Location() != null) {
+
+            final S3OutputLocation s3Location = resourceModelOutputLocation.getS3Location();
+
+            final com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation serviceModelS3Location =
+                new com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation()
+                    .withOutputS3BucketName(s3Location.getOutputS3BucketName())
+                    .withOutputS3Region(s3Location.getOutputS3Region())
+                    .withOutputS3KeyPrefix(s3Location.getOutputS3KeyPrefix());
+
+            final com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation serviceModelOutputLocation =
+                new com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation()
+                    .withS3Location(serviceModelS3Location);
+
+            updateAssociationRequest.setOutputLocation(serviceModelOutputLocation);
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getAutomationTargetParameterName())) {
+            updateAssociationRequest.setAutomationTargetParameterName(model.getAutomationTargetParameterName());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getMaxErrors())) {
+            updateAssociationRequest.setMaxErrors(model.getMaxErrors());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getMaxConcurrency())) {
+            updateAssociationRequest.setMaxConcurrency(model.getMaxConcurrency());
+        }
+
+        if (!StringUtils.isNullOrEmpty(model.getComplianceSeverity())) {
+            updateAssociationRequest.setComplianceSeverity(model.getComplianceSeverity());
+        }
+
+        return updateAssociationRequest;
     }
 }

--- a/aws-ssm-association/src/main/java/com/aws/ssm/association/util/ResourceModelServiceModelConverter.java
+++ b/aws-ssm-association/src/main/java/com/aws/ssm/association/util/ResourceModelServiceModelConverter.java
@@ -1,0 +1,108 @@
+package com.aws.ssm.association.util;
+
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDescription;
+import com.aws.ssm.association.InstanceAssociationOutputLocation;
+import com.aws.ssm.association.ResourceModel;
+import com.aws.ssm.association.S3OutputLocation;
+import com.aws.ssm.association.Target;
+import com.amazonaws.util.StringUtils;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class for converting between ResourceModel and service model object types.
+ */
+public class ResourceModelServiceModelConverter {
+
+    /**
+     * Converts State Manager's AssociationDescription service object to ResourceModel.
+     *
+     * @param association AssociationDescription representing association to convert to the model.
+     * @return ResourceModel representation of the association.
+     */
+    public static ResourceModel associationDescriptionToResourceModel(
+        final AssociationDescription association) {
+
+        final ResourceModel model = new ResourceModel();
+
+        model.setAssociationId(association.getAssociationId());
+        model.setName(association.getName());
+
+        if (!StringUtils.isNullOrEmpty(association.getAssociationName())) {
+            model.setAssociationName(association.getAssociationName());
+        }
+
+        if (!StringUtils.isNullOrEmpty(association.getDocumentVersion())) {
+            model.setDocumentVersion(association.getDocumentVersion());
+        }
+
+        if (!StringUtils.isNullOrEmpty(association.getInstanceId())) {
+            model.setInstanceId(association.getInstanceId());
+        }
+
+        if (MapUtils.isNotEmpty(association.getParameters())) {
+            model.setParameters(association.getParameters());
+        }
+
+        if (!StringUtils.isNullOrEmpty(association.getScheduleExpression())) {
+            model.setScheduleExpression(association.getScheduleExpression());
+        }
+
+        if (CollectionUtils.isNotEmpty(association.getTargets())) {
+            final List<Target> convertedTargets =
+                association.getTargets().stream()
+                    .map(associationTarget -> {
+                        Target resourceModelTarget = new Target();
+                        resourceModelTarget.setKey(associationTarget.getKey());
+                        resourceModelTarget.setValues(associationTarget.getValues());
+                        return resourceModelTarget;
+                    })
+                    .collect(Collectors.toList());
+
+            model.setTargets(convertedTargets);
+        }
+
+        final com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation serviceModelOutputLocation =
+            association.getOutputLocation();
+
+        if (serviceModelOutputLocation != null
+            && serviceModelOutputLocation.getS3Location() != null) {
+
+            final com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation s3Location =
+                serviceModelOutputLocation.getS3Location();
+
+            final S3OutputLocation resourceModelS3Location = new S3OutputLocation();
+
+            resourceModelS3Location.setOutputS3BucketName(s3Location.getOutputS3BucketName());
+            resourceModelS3Location.setOutputS3Region(s3Location.getOutputS3Region());
+            resourceModelS3Location.setOutputS3KeyPrefix(s3Location.getOutputS3KeyPrefix());
+
+            final InstanceAssociationOutputLocation resourceModelOutputLocation = new InstanceAssociationOutputLocation();
+
+            resourceModelOutputLocation.setS3Location(resourceModelS3Location);
+
+            model.setOutputLocation(resourceModelOutputLocation);
+        }
+
+        if (!StringUtils.isNullOrEmpty(association.getAutomationTargetParameterName())) {
+            model.setAutomationTargetParameterName(association.getAutomationTargetParameterName());
+        }
+
+        if (!StringUtils.isNullOrEmpty(association.getMaxErrors())) {
+            model.setMaxErrors(association.getMaxErrors());
+        }
+
+        if (!StringUtils.isNullOrEmpty(association.getMaxConcurrency())) {
+            model.setMaxConcurrency(association.getMaxConcurrency());
+        }
+
+        if (!StringUtils.isNullOrEmpty(association.getComplianceSeverity())) {
+            model.setComplianceSeverity(association.getComplianceSeverity());
+        }
+
+        return model;
+    }
+}

--- a/aws-ssm-association/src/test/java/com/aws/ssm/association/CreateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/aws/ssm/association/CreateHandlerTest.java
@@ -1,25 +1,77 @@
 package com.aws.ssm.association;
 
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
+import com.amazonaws.cloudformation.proxy.HandlerErrorCode;
 import com.amazonaws.cloudformation.proxy.Logger;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
 import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationAlreadyExistsException;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDescription;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationLimitExceededException;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationOverview;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationStatusName;
+import com.amazonaws.services.simplesystemsmanagement.model.CreateAssociationRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.CreateAssociationResult;
+import com.amazonaws.services.simplesystemsmanagement.model.DescribeAssociationRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.DescribeAssociationResult;
+import com.amazonaws.services.simplesystemsmanagement.model.InternalServerErrorException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidDocumentException;
+import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest {
 
+    private static final String ASSOCIATION_NAME = "TestAssociation";
+    private static final String DOCUMENT_NAME = "TestDocument";
+    private static final String DOCUMENT_VERSION = "2";
+    private static final String SCHEDULE_EXPRESSION = "rate(30)";
+    private static final String COMPLIANCE_SEVERITY = "CRITICAL";
+    private static final String ASSOCIATION_ID = "test-12345-associationId";
+    private static final String MAX_CONCURRENCY = "50%";
+    private static final String MAX_ERRORS = "10%";
+    private static final String INSTANCE_ID = "i-1234abcd";
+    private static final String AUTOMATION_TARGET_PARAMETER_NAME = "InstanceId";
+
+    private static final String S3_BUCKET_REGION = "us-east-1";
+    private static final String S3_BUCKET_NAME = "test-bucket";
+    private static final String S3_KEY_PREFIX = "test-association-output-location";
+    private static final InstanceAssociationOutputLocation OUTPUT_LOCATION =
+        new InstanceAssociationOutputLocation(
+            new S3OutputLocation(S3_BUCKET_REGION, S3_BUCKET_NAME, S3_KEY_PREFIX));
+
+    private static final String TARGET_KEY = "tag:domain";
+    private static final String TARGET_VALUE = "test";
+    private static final List<Target> TARGETS =
+        Collections.singletonList(
+            new Target(TARGET_KEY, Collections.singletonList(TARGET_VALUE)));
+
+    private static final Map<String, List<String>> PARAMETERS =
+        ImmutableMap.<String, List<String>>builder()
+            .put("command", Collections.singletonList("echo 'hello world'"))
+            .build();
+
+    private CreateHandler handler = new CreateHandler();
     @Mock
     private AmazonWebServicesClientProxy proxy;
-
     @Mock
     private Logger logger;
 
@@ -30,10 +82,213 @@ public class CreateHandlerTest {
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
-        final CreateHandler handler = new CreateHandler();
+    public void handleRequestWithAllParametersNonAutomationNonLegacy() {
+        final ResourceModel model = ResourceModel.builder()
+            .associationName(ASSOCIATION_NAME)
+            .name(DOCUMENT_NAME)
+            .documentVersion(DOCUMENT_VERSION)
+            .parameters(PARAMETERS)
+            .targets(TARGETS)
+            .scheduleExpression(SCHEDULE_EXPRESSION)
+            .complianceSeverity(COMPLIANCE_SEVERITY)
+            .maxConcurrency(MAX_CONCURRENCY)
+            .maxErrors(MAX_ERRORS)
+            .outputLocation(OUTPUT_LOCATION)
+            .build();
 
-        final ResourceModel model = ResourceModel.builder().build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withAssociationName(ASSOCIATION_NAME)
+                .withDocumentVersion(DOCUMENT_VERSION)
+                .withParameters(PARAMETERS)
+                .withTargets(Collections.singletonList(
+                    new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(TARGET_KEY)
+                        .withValues(TARGET_VALUE)))
+                .withScheduleExpression(SCHEDULE_EXPRESSION)
+                .withComplianceSeverity(COMPLIANCE_SEVERITY)
+                .withMaxConcurrency(MAX_CONCURRENCY)
+                .withMaxErrors(MAX_ERRORS)
+                .withOutputLocation(new com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation()
+                    .withS3Location(
+                        new com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation()
+                            .withOutputS3Region(S3_BUCKET_REGION)
+                            .withOutputS3BucketName(S3_BUCKET_NAME)
+                            .withOutputS3KeyPrefix(S3_KEY_PREFIX)));
+
+        final CreateAssociationResult result =
+            new CreateAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(CreateAssociationRequest.class),
+                ArgumentMatchers.<Function<CreateAssociationRequest, CreateAssociationResult>>any()))
+            .thenReturn(result);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        ResourceModel expectedModel = request.getDesiredResourceState();
+        expectedModel.setAssociationId(ASSOCIATION_ID);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(expectedModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWithAllParametersLegacyAssociation() {
+        final ResourceModel model = ResourceModel.builder()
+            .associationName(ASSOCIATION_NAME)
+            .name(DOCUMENT_NAME)
+            .documentVersion(DOCUMENT_VERSION)
+            .parameters(PARAMETERS)
+            .instanceId(INSTANCE_ID)
+            .scheduleExpression(SCHEDULE_EXPRESSION)
+            .complianceSeverity(COMPLIANCE_SEVERITY)
+            .maxConcurrency(MAX_CONCURRENCY)
+            .maxErrors(MAX_ERRORS)
+            .outputLocation(OUTPUT_LOCATION)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withAssociationName(ASSOCIATION_NAME)
+                .withDocumentVersion(DOCUMENT_VERSION)
+                .withParameters(PARAMETERS)
+                .withInstanceId(INSTANCE_ID)
+                .withScheduleExpression(SCHEDULE_EXPRESSION)
+                .withComplianceSeverity(COMPLIANCE_SEVERITY)
+                .withMaxConcurrency(MAX_CONCURRENCY)
+                .withMaxErrors(MAX_ERRORS)
+                .withOutputLocation(new com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation()
+                    .withS3Location(
+                        new com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation()
+                            .withOutputS3Region(S3_BUCKET_REGION)
+                            .withOutputS3BucketName(S3_BUCKET_NAME)
+                            .withOutputS3KeyPrefix(S3_KEY_PREFIX)));
+
+        final CreateAssociationResult result =
+            new CreateAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(CreateAssociationRequest.class),
+                ArgumentMatchers.<Function<CreateAssociationRequest, CreateAssociationResult>>any()))
+            .thenReturn(result);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        ResourceModel expectedModel = request.getDesiredResourceState();
+        expectedModel.setAssociationId(ASSOCIATION_ID);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(expectedModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWithAllParametersAutomationAssociation() {
+        final ResourceModel model = ResourceModel.builder()
+            .associationName(ASSOCIATION_NAME)
+            .name(DOCUMENT_NAME)
+            .documentVersion(DOCUMENT_VERSION)
+            .parameters(PARAMETERS)
+            .targets(TARGETS)
+            .scheduleExpression(SCHEDULE_EXPRESSION)
+            .complianceSeverity(COMPLIANCE_SEVERITY)
+            .maxConcurrency(MAX_CONCURRENCY)
+            .maxErrors(MAX_ERRORS)
+            .outputLocation(OUTPUT_LOCATION)
+            .automationTargetParameterName(AUTOMATION_TARGET_PARAMETER_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withAssociationName(ASSOCIATION_NAME)
+                .withDocumentVersion(DOCUMENT_VERSION)
+                .withParameters(PARAMETERS)
+                .withTargets(Collections.singletonList(
+                    new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(TARGET_KEY)
+                        .withValues(TARGET_VALUE)))
+                .withScheduleExpression(SCHEDULE_EXPRESSION)
+                .withComplianceSeverity(COMPLIANCE_SEVERITY)
+                .withMaxConcurrency(MAX_CONCURRENCY)
+                .withMaxErrors(MAX_ERRORS)
+                .withOutputLocation(new com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation()
+                    .withS3Location(
+                        new com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation()
+                            .withOutputS3Region(S3_BUCKET_REGION)
+                            .withOutputS3BucketName(S3_BUCKET_NAME)
+                            .withOutputS3KeyPrefix(S3_KEY_PREFIX)))
+                .withAutomationTargetParameterName(AUTOMATION_TARGET_PARAMETER_NAME);
+
+        final CreateAssociationResult result =
+            new CreateAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(CreateAssociationRequest.class),
+                ArgumentMatchers.<Function<CreateAssociationRequest, CreateAssociationResult>>any()))
+            .thenReturn(result);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        ResourceModel expectedModel = request.getDesiredResourceState();
+        expectedModel.setAssociationId(ASSOCIATION_ID);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(expectedModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWithNoDocumentName() {
+        final ResourceModel model = ResourceModel.builder()
+            .associationName(ASSOCIATION_NAME)
+            .parameters(PARAMETERS)
+            .targets(TARGETS)
+            .scheduleExpression(SCHEDULE_EXPRESSION)
+            .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
@@ -43,12 +298,516 @@ public class CreateHandlerTest {
             = handler.handleRequest(proxy, request, null, logger);
 
         assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo("Document name must be specified to create an association.");
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequestWhenAssociationAlreadyExists() {
+        final ResourceModel model = ResourceModel.builder()
+            .associationName(ASSOCIATION_NAME)
+            .name(DOCUMENT_NAME)
+            .documentVersion(DOCUMENT_VERSION)
+            .parameters(PARAMETERS)
+            .targets(TARGETS)
+            .scheduleExpression(SCHEDULE_EXPRESSION)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final String errorMessage = "This association already exists.";
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(CreateAssociationRequest.class),
+                ArgumentMatchers.<Function<CreateAssociationRequest, CreateAssociationResult>>any()))
+            .thenThrow(new AssociationAlreadyExistsException(errorMessage));
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        // actual error message will have service/request and other details appended
+        assertThat(response.getMessage()).contains(errorMessage);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+    }
+
+    @Test
+    public void handleRequestWhenServiceLimitExceeded() {
+        final ResourceModel model = ResourceModel.builder()
+            .associationName(ASSOCIATION_NAME)
+            .name(DOCUMENT_NAME)
+            .documentVersion(DOCUMENT_VERSION)
+            .parameters(PARAMETERS)
+            .targets(TARGETS)
+            .scheduleExpression(SCHEDULE_EXPRESSION)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final String errorMessage = "Association limit exceeded for your account.";
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(CreateAssociationRequest.class),
+                ArgumentMatchers.<Function<CreateAssociationRequest, CreateAssociationResult>>any()))
+            .thenThrow(new AssociationLimitExceededException(errorMessage));
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        // actual error message will have service/request and other details appended
+        assertThat(response.getMessage()).contains(errorMessage);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.ServiceLimitExceeded);
+    }
+
+    @Test
+    public void handleRequestWhenInvalidRequestProvided() {
+        final ResourceModel model = ResourceModel.builder()
+            .name(DOCUMENT_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final String errorMessage = "Invalid request.";
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(CreateAssociationRequest.class),
+                ArgumentMatchers.<Function<CreateAssociationRequest, CreateAssociationResult>>any()))
+            .thenThrow(new InvalidDocumentException(errorMessage));
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        // actual error message will have service/request and other details appended
+        assertThat(response.getMessage()).contains(errorMessage);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequestWhenInternalServerErrorHappened() {
+        final ResourceModel model = ResourceModel.builder()
+            .name(DOCUMENT_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final String errorMessage = "Internal server error.";
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(CreateAssociationRequest.class),
+                ArgumentMatchers.<Function<CreateAssociationRequest, CreateAssociationResult>>any()))
+            .thenThrow(new InternalServerErrorException(errorMessage));
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        // actual error message will have service/request and other details appended
+        assertThat(response.getMessage()).contains(errorMessage);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.ServiceInternalError);
+    }
+
+    @Test
+    public void handleRequestWhenUnknownExceptionHappened() {
+        final ResourceModel model = ResourceModel.builder()
+            .name(DOCUMENT_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final String errorMessage = "Unknown failure occurred.";
+
+        final IllegalArgumentException unknownServiceException = new IllegalArgumentException(errorMessage);
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(CreateAssociationRequest.class),
+                ArgumentMatchers.<Function<CreateAssociationRequest, CreateAssociationResult>>any()))
+            .thenThrow(unknownServiceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        verify(logger).log(eq(unknownServiceException.getMessage()));
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).contains(errorMessage);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.GeneralServiceException);
+    }
+
+    @Test
+    public void handleRequestWhenWaitForAssociationSuccessIsSetToFalse() {
+        final ResourceModel model = ResourceModel.builder()
+            .name(DOCUMENT_NAME)
+            .targets(TARGETS)
+            .parameters(PARAMETERS)
+            .waitForAssociationSuccess(Boolean.FALSE)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withParameters(PARAMETERS)
+                .withTargets(Collections.singletonList(
+                    new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(TARGET_KEY)
+                        .withValues(TARGET_VALUE)));
+
+        final CreateAssociationResult result =
+            new CreateAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(CreateAssociationRequest.class),
+                ArgumentMatchers.<Function<CreateAssociationRequest, CreateAssociationResult>>any()))
+            .thenReturn(result);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        final ResourceModel expectedModel = request.getDesiredResourceState();
+        expectedModel.setAssociationId(ASSOCIATION_ID);
+        // this flag is only used to determine how to start Create operation
+        // it is not needed to understand the model of the Association resource being created
+        expectedModel.setWaitForAssociationSuccess(null);
+
+        assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(expectedModel);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWhenWaitForAssociationSuccessIsSetToTrue() {
+        final ResourceModel model = ResourceModel.builder()
+            .name(DOCUMENT_NAME)
+            .targets(TARGETS)
+            .parameters(PARAMETERS)
+            .waitForAssociationSuccess(Boolean.TRUE)
+            .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withParameters(PARAMETERS)
+                .withTargets(Collections.singletonList(
+                    new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(TARGET_KEY)
+                        .withValues(TARGET_VALUE)));
+
+        final CreateAssociationResult result =
+            new CreateAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(CreateAssociationRequest.class),
+                ArgumentMatchers.<Function<CreateAssociationRequest, CreateAssociationResult>>any()))
+            .thenReturn(result);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        final CallbackContext expectedCallbackContext = CallbackContext.builder()
+            .associationDescription(associationDescription)
+            .stabilizationRetriesRemaining(10)
+            .build();
+
+        final ResourceModel expectedModel = request.getDesiredResourceState();
+        expectedModel.setAssociationId(ASSOCIATION_ID);
+        // this flag is only used to determine how to start Create operation
+        // it is not needed to understand the model of the Association resource being created
+        expectedModel.setWaitForAssociationSuccess(null);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isEqualTo(expectedCallbackContext);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(15);
+        assertThat(response.getResourceModel()).isEqualTo(expectedModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWhenCallbackContextIsPresentWithRetriesRemainingAndAssociationSuccess() {
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .name(DOCUMENT_NAME)
+            .targets(TARGETS)
+            .parameters(PARAMETERS)
+            .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withParameters(PARAMETERS)
+                .withTargets(Collections.singletonList(
+                    new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(TARGET_KEY)
+                        .withValues(TARGET_VALUE)))
+                .withOverview(new AssociationOverview()
+                    .withStatus(AssociationStatusName.Success.name()));
+
+        final DescribeAssociationResult result =
+            new DescribeAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DescribeAssociationRequest.class),
+                ArgumentMatchers.<Function<DescribeAssociationRequest, DescribeAssociationResult>>any()))
+            .thenReturn(result);
+
+        final CallbackContext callbackContext = CallbackContext.builder()
+            .associationDescription(associationDescription)
+            .stabilizationRetriesRemaining(10)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, callbackContext, logger);
+
+        final ResourceModel expectedModel = request.getDesiredResourceState();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(expectedModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWhenCallbackContextIsPresentWithRetriesRemainingAndAssociationPending() {
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .name(DOCUMENT_NAME)
+            .targets(TARGETS)
+            .parameters(PARAMETERS)
+            .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withParameters(PARAMETERS)
+                .withTargets(Collections.singletonList(
+                    new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(TARGET_KEY)
+                        .withValues(TARGET_VALUE)))
+                .withOverview(new AssociationOverview()
+                    .withStatus(AssociationStatusName.Pending.name()));
+
+        final DescribeAssociationResult result =
+            new DescribeAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DescribeAssociationRequest.class),
+                ArgumentMatchers.<Function<DescribeAssociationRequest, DescribeAssociationResult>>any()))
+            .thenReturn(result);
+
+        final CallbackContext callbackContext = CallbackContext.builder()
+            .associationDescription(associationDescription)
+            .stabilizationRetriesRemaining(10)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, callbackContext, logger);
+
+        final ResourceModel expectedModel = request.getDesiredResourceState();
+
+        final CallbackContext expectedCallbackContext = CallbackContext.builder()
+            .associationDescription(associationDescription)
+            .stabilizationRetriesRemaining(9)
+            .build();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
+        assertThat(response.getCallbackContext()).isEqualTo(expectedCallbackContext);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(15);
+        assertThat(response.getResourceModel()).isEqualTo(expectedModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWhenCallbackContextIsPresentWithRetriesRemainingAndAssociationFailed() {
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .name(DOCUMENT_NAME)
+            .targets(TARGETS)
+            .parameters(PARAMETERS)
+            .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withParameters(PARAMETERS)
+                .withTargets(Collections.singletonList(
+                    new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(TARGET_KEY)
+                        .withValues(TARGET_VALUE)))
+                .withOverview(new AssociationOverview()
+                    .withStatus(AssociationStatusName.Failed.name())
+                .withDetailedStatus("Execution failed"));
+
+        final DescribeAssociationResult result =
+            new DescribeAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DescribeAssociationRequest.class),
+                ArgumentMatchers.<Function<DescribeAssociationRequest, DescribeAssociationResult>>any()))
+            .thenReturn(result);
+
+        final CallbackContext callbackContext = CallbackContext.builder()
+            .associationDescription(associationDescription)
+            .stabilizationRetriesRemaining(10)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, callbackContext, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo("Association failed; detailed status: Execution failed");
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotStabilized);
+    }
+
+    @Test
+    public void handleRequestWhenCallbackContextIsPresentWithLastRetryRemaining() {
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .name(DOCUMENT_NAME)
+            .targets(TARGETS)
+            .parameters(PARAMETERS)
+            .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withParameters(PARAMETERS)
+                .withTargets(Collections.singletonList(
+                    new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(TARGET_KEY)
+                        .withValues(TARGET_VALUE)))
+                .withOverview(new AssociationOverview()
+                    .withStatus(AssociationStatusName.Pending.name()));
+
+        final DescribeAssociationResult result =
+            new DescribeAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DescribeAssociationRequest.class),
+                ArgumentMatchers.<Function<DescribeAssociationRequest, DescribeAssociationResult>>any()))
+            .thenReturn(result);
+
+        final CallbackContext callbackContext = CallbackContext.builder()
+            .associationDescription(associationDescription)
+            .stabilizationRetriesRemaining(1)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, callbackContext, logger);
+
+        // since there is only one retry left, and the association status will still be Pending, we should expect failure
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo("Timed out waiting for association to succeed.");
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotStabilized);
     }
 }

--- a/aws-ssm-association/src/test/java/com/aws/ssm/association/DeleteHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/aws/ssm/association/DeleteHandlerTest.java
@@ -1,25 +1,41 @@
 package com.aws.ssm.association;
 
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
+import com.amazonaws.cloudformation.proxy.HandlerErrorCode;
 import com.amazonaws.cloudformation.proxy.Logger;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
 import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDoesNotExistException;
+import com.amazonaws.services.simplesystemsmanagement.model.DeleteAssociationRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.DeleteAssociationResult;
+import com.amazonaws.services.simplesystemsmanagement.model.InternalServerErrorException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidDocumentException;
+import com.amazonaws.services.simplesystemsmanagement.model.TooManyUpdatesException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.function.Function;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteHandlerTest {
 
+    private static final String ASSOCIATION_ID = "test-12345-associationId";
+    private static final String INSTANCE_ID = "i-1234abcd";
+    private static final String DOCUMENT_NAME = "TestDocument";
+
+    final DeleteHandler handler = new DeleteHandler();
     @Mock
     private AmazonWebServicesClientProxy proxy;
-
     @Mock
     private Logger logger;
 
@@ -30,10 +46,11 @@ public class DeleteHandlerTest {
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
-        final DeleteHandler handler = new DeleteHandler();
+    public void handleRequestWithAssociationId() {
 
-        final ResourceModel model = ResourceModel.builder().build();
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
@@ -46,9 +63,225 @@ public class DeleteHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel()).isNull();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWithInstanceIdAndDocumentName() {
+
+        final ResourceModel model = ResourceModel.builder()
+            .instanceId(INSTANCE_ID)
+            .name(DOCUMENT_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWithNoRequiredParametersPresent() {
+
+        final ResourceModel model = ResourceModel.builder()
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(model);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage())
+            .isEqualTo("AssociationId, or InstanceId and Document Name must be specified to delete an association.");
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequestWhenAssociationDoesNotExist() {
+
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final AssociationDoesNotExistException serviceException =
+            new AssociationDoesNotExistException("Requested association does not exist.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DeleteAssociationRequest.class),
+                ArgumentMatchers.<Function<DeleteAssociationRequest, DeleteAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+    }
+
+    @Test
+    public void handleRequestWhenTooManyUpdatesHappened() {
+
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final TooManyUpdatesException serviceException =
+            new TooManyUpdatesException("Too many updates happened at the same time; try again later.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DeleteAssociationRequest.class),
+                ArgumentMatchers.<Function<DeleteAssociationRequest, DeleteAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(model);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.Throttling);
+    }
+
+    @Test
+    public void handleRequestWhenDocumentDoesNotExist() {
+
+        final ResourceModel model = ResourceModel.builder()
+            .instanceId(INSTANCE_ID)
+            .name(DOCUMENT_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final InvalidDocumentException serviceException =
+            new InvalidDocumentException("Document name provided does not exist");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DeleteAssociationRequest.class),
+                ArgumentMatchers.<Function<DeleteAssociationRequest, DeleteAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(model);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequestWhenInternalServerErrorHappened() {
+
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final InternalServerErrorException serviceException =
+            new InternalServerErrorException("Something unexpected occurred on the server.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DeleteAssociationRequest.class),
+                ArgumentMatchers.<Function<DeleteAssociationRequest, DeleteAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(model);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.ServiceInternalError);
+    }
+
+    @Test
+    public void handleRequestWhenUnexpectedExceptionHappened() {
+
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final IllegalArgumentException serviceException =
+            new IllegalArgumentException("Unknown failure occurred.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DeleteAssociationRequest.class),
+                ArgumentMatchers.<Function<DeleteAssociationRequest, DeleteAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(model);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.GeneralServiceException);
     }
 }

--- a/aws-ssm-association/src/test/java/com/aws/ssm/association/ReadHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/aws/ssm/association/ReadHandlerTest.java
@@ -1,25 +1,42 @@
 package com.aws.ssm.association;
 
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
+import com.amazonaws.cloudformation.proxy.HandlerErrorCode;
 import com.amazonaws.cloudformation.proxy.Logger;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
 import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDescription;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDoesNotExistException;
+import com.amazonaws.services.simplesystemsmanagement.model.DescribeAssociationRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.DescribeAssociationResult;
+import com.amazonaws.services.simplesystemsmanagement.model.InternalServerErrorException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidAssociationVersionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.function.Function;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest {
 
+    private static final String DOCUMENT_NAME = "TestDocument";
+    private static final String ASSOCIATION_ID = "test-12345-associationId";
+
+    private ReadHandler handler = new ReadHandler();
     @Mock
     private AmazonWebServicesClientProxy proxy;
-
     @Mock
     private Logger logger;
 
@@ -30,25 +47,178 @@ public class ReadHandlerTest {
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
-        final ReadHandler handler = new ReadHandler();
+    public void handleRequestSimpleSuccess() {
 
-        final ResourceModel model = ResourceModel.builder().build();
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
             .build();
 
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME);
+
+        final DescribeAssociationResult result =
+            new DescribeAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DescribeAssociationRequest.class),
+                ArgumentMatchers.<Function<DescribeAssociationRequest, DescribeAssociationResult>>any()))
+            .thenReturn(result);
+
         final ProgressEvent<ResourceModel, CallbackContext> response
             = handler.handleRequest(proxy, request, null, logger);
+
+        ResourceModel expectedModel = request.getDesiredResourceState();
+        expectedModel.setName(DOCUMENT_NAME);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(expectedModel);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWhenAssociationDoesNotExist() {
+
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final AssociationDoesNotExistException serviceException =
+            new AssociationDoesNotExistException("Requested association does not exist");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DescribeAssociationRequest.class),
+                ArgumentMatchers.<Function<DescribeAssociationRequest, DescribeAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
+    }
+
+    @Test
+    public void handleRequestWhenAssociationVersionInvalid() {
+
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final InvalidAssociationVersionException serviceException =
+            new InvalidAssociationVersionException("Requested association version is invalid");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DescribeAssociationRequest.class),
+                ArgumentMatchers.<Function<DescribeAssociationRequest, DescribeAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequestWhenInternalServerErrorHappened() {
+
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final InternalServerErrorException serviceException =
+            new InternalServerErrorException("Internal server error occurred.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DescribeAssociationRequest.class),
+                ArgumentMatchers.<Function<DescribeAssociationRequest, DescribeAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.ServiceInternalError);
+    }
+
+    @Test
+    public void handleRequestWhenUnknownExceptionHappened() {
+
+        final ResourceModel model = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final IllegalArgumentException serviceException =
+            new IllegalArgumentException("Unknown failure occurred.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(DescribeAssociationRequest.class),
+                ArgumentMatchers.<Function<DescribeAssociationRequest, DescribeAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        verify(logger).log(eq(serviceException.getMessage()));
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.GeneralServiceException);
     }
 }

--- a/aws-ssm-association/src/test/java/com/aws/ssm/association/UpdateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/aws/ssm/association/UpdateHandlerTest.java
@@ -1,27 +1,80 @@
 package com.aws.ssm.association;
 
 import com.amazonaws.cloudformation.proxy.AmazonWebServicesClientProxy;
+import com.amazonaws.cloudformation.proxy.HandlerErrorCode;
 import com.amazonaws.cloudformation.proxy.Logger;
 import com.amazonaws.cloudformation.proxy.OperationStatus;
 import com.amazonaws.cloudformation.proxy.ProgressEvent;
 import com.amazonaws.cloudformation.proxy.ResourceHandlerRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDescription;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDoesNotExistException;
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationVersionLimitExceededException;
+import com.amazonaws.services.simplesystemsmanagement.model.InternalServerErrorException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidScheduleException;
+import com.amazonaws.services.simplesystemsmanagement.model.InvalidUpdateException;
+import com.amazonaws.services.simplesystemsmanagement.model.TooManyUpdatesException;
+import com.amazonaws.services.simplesystemsmanagement.model.UpdateAssociationRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.UpdateAssociationResult;
+import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class UpdateHandlerTest {
+
+    private UpdateHandler handler = new UpdateHandler();
 
     @Mock
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
     private Logger logger;
+
+    private static final String DOCUMENT_NAME = "NewTestDocument";
+    private static final String ASSOCIATION_ID = "test-12345-associationId";
+    private static final String ASSOCIATION_NAME = "TestAssociation";
+    private static final String NEW_ASSOCIATION_NAME = "NewTestAssociation";
+    private static final String DOCUMENT_VERSION = "2";
+    private static final String SCHEDULE_EXPRESSION = "rate(30)";
+    private static final String COMPLIANCE_SEVERITY = "CRITICAL";
+    private static final String MAX_CONCURRENCY = "50%";
+    private static final String MAX_ERRORS = "10%";
+    private static final String INSTANCE_ID = "i-1234abcd";
+    private static final String AUTOMATION_TARGET_PARAMETER_NAME = "InstanceId";
+
+    private static final String S3_BUCKET_REGION = "us-east-1";
+    private static final String S3_BUCKET_NAME = "test-bucket";
+    private static final String S3_KEY_PREFIX = "test-association-output-location";
+    private static final InstanceAssociationOutputLocation OUTPUT_LOCATION =
+        new InstanceAssociationOutputLocation(
+            new S3OutputLocation(S3_BUCKET_REGION, S3_BUCKET_NAME, S3_KEY_PREFIX));
+
+    private static final String TARGET_KEY = "tag:domain";
+    private static final String TARGET_VALUE = "test";
+    private static final List<Target> TARGETS =
+        Collections.singletonList(
+            new Target(TARGET_KEY, Collections.singletonList(TARGET_VALUE)));
+
+    private static final Map<String, List<String>> PARAMETERS =
+        ImmutableMap.<String, List<String>>builder()
+            .put("command", Collections.singletonList("echo 'hello world'"))
+            .build();
 
     @BeforeEach
     public void setup() {
@@ -30,14 +83,63 @@ public class UpdateHandlerTest {
     }
 
     @Test
-    public void handleRequest_SimpleSuccess() {
-        final UpdateHandler handler = new UpdateHandler();
+    public void handleRequestWithAllParametersNonAutomationNonLegacy() {
 
-        final ResourceModel model = ResourceModel.builder().build();
+        final ResourceModel.ResourceModelBuilder resourceModelBuilder =
+            ResourceModel.builder()
+                .associationId(ASSOCIATION_ID)
+                .associationName(ASSOCIATION_NAME)
+                .name(DOCUMENT_NAME)
+                .documentVersion(DOCUMENT_VERSION)
+                .parameters(PARAMETERS)
+                .targets(TARGETS)
+                .scheduleExpression(SCHEDULE_EXPRESSION)
+                .complianceSeverity(COMPLIANCE_SEVERITY)
+                .maxConcurrency(MAX_CONCURRENCY)
+                .maxErrors(MAX_ERRORS)
+                .outputLocation(OUTPUT_LOCATION);
+
+        final ResourceModel previousModel = resourceModelBuilder.build();
+        final ResourceModel desiredModel = resourceModelBuilder
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-            .desiredResourceState(model)
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
             .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withAssociationName(NEW_ASSOCIATION_NAME)
+                .withDocumentVersion(DOCUMENT_VERSION)
+                .withParameters(PARAMETERS)
+                .withTargets(Collections.singletonList(
+                    new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(TARGET_KEY)
+                        .withValues(TARGET_VALUE)))
+                .withScheduleExpression(SCHEDULE_EXPRESSION)
+                .withComplianceSeverity(COMPLIANCE_SEVERITY)
+                .withMaxConcurrency(MAX_CONCURRENCY)
+                .withMaxErrors(MAX_ERRORS)
+                .withOutputLocation(new com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation()
+                    .withS3Location(
+                        new com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation()
+                            .withOutputS3Region(S3_BUCKET_REGION)
+                            .withOutputS3BucketName(S3_BUCKET_NAME)
+                            .withOutputS3KeyPrefix(S3_KEY_PREFIX)));
+
+        final UpdateAssociationResult result =
+            new UpdateAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(UpdateAssociationRequest.class),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResult>>any()))
+            .thenReturn(result);
 
         final ProgressEvent<ResourceModel, CallbackContext> response
             = handler.handleRequest(proxy, request, null, logger);
@@ -46,9 +148,455 @@ public class UpdateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(desiredModel);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWithAllParametersLegacy() {
+
+        final ResourceModel.ResourceModelBuilder resourceModelBuilder =
+            ResourceModel.builder()
+                .associationId(ASSOCIATION_ID)
+                .associationName(ASSOCIATION_NAME)
+                .name(DOCUMENT_NAME)
+                .documentVersion(DOCUMENT_VERSION)
+                .parameters(PARAMETERS)
+                .instanceId(INSTANCE_ID)
+                .scheduleExpression(SCHEDULE_EXPRESSION)
+                .complianceSeverity(COMPLIANCE_SEVERITY)
+                .maxConcurrency(MAX_CONCURRENCY)
+                .maxErrors(MAX_ERRORS)
+                .outputLocation(OUTPUT_LOCATION);
+
+        final ResourceModel previousModel = resourceModelBuilder.build();
+        final ResourceModel desiredModel = resourceModelBuilder
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withAssociationName(NEW_ASSOCIATION_NAME)
+                .withDocumentVersion(DOCUMENT_VERSION)
+                .withParameters(PARAMETERS)
+                .withInstanceId(INSTANCE_ID)
+                .withScheduleExpression(SCHEDULE_EXPRESSION)
+                .withComplianceSeverity(COMPLIANCE_SEVERITY)
+                .withMaxConcurrency(MAX_CONCURRENCY)
+                .withMaxErrors(MAX_ERRORS)
+                .withOutputLocation(new com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation()
+                    .withS3Location(
+                        new com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation()
+                            .withOutputS3Region(S3_BUCKET_REGION)
+                            .withOutputS3BucketName(S3_BUCKET_NAME)
+                            .withOutputS3KeyPrefix(S3_KEY_PREFIX)));
+
+        final UpdateAssociationResult result =
+            new UpdateAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(UpdateAssociationRequest.class),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResult>>any()))
+            .thenReturn(result);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(desiredModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWithAllParametersAutomationAssociation() {
+
+        final ResourceModel.ResourceModelBuilder resourceModelBuilder =
+            ResourceModel.builder()
+                .associationId(ASSOCIATION_ID)
+                .associationName(ASSOCIATION_NAME)
+                .name(DOCUMENT_NAME)
+                .documentVersion(DOCUMENT_VERSION)
+                .parameters(PARAMETERS)
+                .targets(TARGETS)
+                .scheduleExpression(SCHEDULE_EXPRESSION)
+                .complianceSeverity(COMPLIANCE_SEVERITY)
+                .maxConcurrency(MAX_CONCURRENCY)
+                .maxErrors(MAX_ERRORS)
+                .outputLocation(OUTPUT_LOCATION)
+                .automationTargetParameterName(AUTOMATION_TARGET_PARAMETER_NAME);
+
+        final ResourceModel previousModel = resourceModelBuilder.build();
+        final ResourceModel desiredModel = resourceModelBuilder
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withAssociationName(NEW_ASSOCIATION_NAME)
+                .withDocumentVersion(DOCUMENT_VERSION)
+                .withParameters(PARAMETERS)
+                .withTargets(Collections.singletonList(
+                    new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(TARGET_KEY)
+                        .withValues(TARGET_VALUE)))
+                .withScheduleExpression(SCHEDULE_EXPRESSION)
+                .withComplianceSeverity(COMPLIANCE_SEVERITY)
+                .withMaxConcurrency(MAX_CONCURRENCY)
+                .withMaxErrors(MAX_ERRORS)
+                .withOutputLocation(new com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation()
+                    .withS3Location(
+                        new com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation()
+                            .withOutputS3Region(S3_BUCKET_REGION)
+                            .withOutputS3BucketName(S3_BUCKET_NAME)
+                            .withOutputS3KeyPrefix(S3_KEY_PREFIX)))
+                .withAutomationTargetParameterName(AUTOMATION_TARGET_PARAMETER_NAME);
+
+        final UpdateAssociationResult result =
+            new UpdateAssociationResult()
+                .withAssociationDescription(associationDescription);
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(UpdateAssociationRequest.class),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResult>>any()))
+            .thenReturn(result);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(desiredModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequestWithNoAssociationId() {
+        final ResourceModel desiredModel = ResourceModel.builder()
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+            .associationName(ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(previousModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo("AssociationId must be present to update the existing association.");
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequestWhenAssociationDoesNotExist() {
+        final ResourceModel desiredModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .associationName(ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final AssociationDoesNotExistException serviceException =
+            new AssociationDoesNotExistException("This association already exists.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(UpdateAssociationRequest.class),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(previousModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
+    }
+
+    @Test
+    public void handleRequestWhenInvalidScheduleProvided() {
+        final ResourceModel desiredModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .scheduleExpression("Every 5 minutes")
+            .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .scheduleExpression(SCHEDULE_EXPRESSION)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final InvalidScheduleException serviceException =
+            new InvalidScheduleException("This schedule expression is invalid.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(UpdateAssociationRequest.class),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(previousModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
+    }
+
+    @Test
+    public void handleRequestWhenUpdateNotSupported() {
+        final ResourceModel desiredModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .instanceId(INSTANCE_ID)
+            .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .targets(TARGETS)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final InvalidUpdateException serviceException =
+            new InvalidUpdateException("This update is unsupported.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(UpdateAssociationRequest.class),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(previousModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotUpdatable);
+    }
+
+    @Test
+    public void handleRequestWhenTooManyUpdatesHappened() {
+        final ResourceModel desiredModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .associationName(ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final TooManyUpdatesException serviceException =
+            new TooManyUpdatesException("Too many updates happened at the same time; try again later.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(UpdateAssociationRequest.class),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(previousModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.Throttling);
+    }
+
+    @Test
+    public void handleRequestWhenAssociationVersionLimitReached() {
+        final ResourceModel desiredModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .associationName(ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final AssociationVersionLimitExceededException serviceException =
+            new AssociationVersionLimitExceededException("This association has reached the maximum number of versions.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(UpdateAssociationRequest.class),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(previousModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.ServiceLimitExceeded);
+    }
+
+    @Test
+    public void handleRequestWhenInternalServerErrorHappened() {
+        final ResourceModel desiredModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .associationName(ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final InternalServerErrorException serviceException =
+            new InternalServerErrorException("Internal server error occurred.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(UpdateAssociationRequest.class),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(previousModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.ServiceInternalError);
+    }
+
+    @Test
+    public void handleRequestWhenUnknownExceptionHappened() {
+        final ResourceModel desiredModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+            .associationId(ASSOCIATION_ID)
+            .associationName(ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final IllegalArgumentException serviceException =
+            new IllegalArgumentException("Unknown failure occurred.");
+
+        when(
+            proxy.injectCredentialsAndInvoke(
+                any(UpdateAssociationRequest.class),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResult>>any()))
+            .thenThrow(serviceException);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        verify(logger).log(eq(serviceException.getMessage()));
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(previousModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(serviceException.getMessage());
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.GeneralServiceException);
     }
 }

--- a/aws-ssm-association/src/test/java/com/aws/ssm/association/util/ResourceModelServiceModelConverterTest.java
+++ b/aws-ssm-association/src/test/java/com/aws/ssm/association/util/ResourceModelServiceModelConverterTest.java
@@ -1,0 +1,184 @@
+package com.aws.ssm.association.util;
+
+import com.amazonaws.services.simplesystemsmanagement.model.AssociationDescription;
+import com.aws.ssm.association.InstanceAssociationOutputLocation;
+import com.aws.ssm.association.ResourceModel;
+import com.aws.ssm.association.S3OutputLocation;
+import com.aws.ssm.association.Target;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResourceModelServiceModelConverterTest {
+
+    private static final String DOCUMENT_NAME = "NewTestDocument";
+    private static final String ASSOCIATION_ID = "test-12345-associationId";
+    private static final String ASSOCIATION_NAME = "TestAssociation";
+    private static final String ASSOCIATION_VERSION = "3";
+    private static final String DOCUMENT_VERSION = "2";
+    private static final String SCHEDULE_EXPRESSION = "rate(30)";
+    private static final String COMPLIANCE_SEVERITY = "CRITICAL";
+    private static final String MAX_CONCURRENCY = "50%";
+    private static final String MAX_ERRORS = "10%";
+    private static final String INSTANCE_ID = "i-1234abcd";
+    private static final String AUTOMATION_TARGET_PARAMETER_NAME = "InstanceId";
+    private static final Date LAST_UPDATE_ASSOCIATION_DATE =
+        Date.from(LocalDateTime.of(2019, 9, 9, 11, 50).toInstant(ZoneOffset.UTC));
+    private static final Date LAST_EXECUTION_DATE =
+        Date.from(LocalDateTime.of(2019, 9, 10, 12, 0).toInstant(ZoneOffset.UTC));
+    private static final Date LAST_SUCCESSFUL_EXECUTION_DATE =
+        Date.from(LocalDateTime.of(2019, 9, 10, 12, 0).toInstant(ZoneOffset.UTC));
+
+    private static final String S3_BUCKET_REGION = "us-east-1";
+    private static final String S3_BUCKET_NAME = "test-bucket";
+    private static final String S3_KEY_PREFIX = "test-association-output-location";
+    private static final InstanceAssociationOutputLocation OUTPUT_LOCATION =
+        new InstanceAssociationOutputLocation(
+            new S3OutputLocation(S3_BUCKET_REGION, S3_BUCKET_NAME, S3_KEY_PREFIX));
+
+    private static final String TARGET_KEY = "tag:domain";
+    private static final String TARGET_VALUE = "test";
+    private static final List<Target> TARGETS =
+        Collections.singletonList(
+            new Target(TARGET_KEY, Collections.singletonList(TARGET_VALUE)));
+
+    private static final Map<String, List<String>> PARAMETERS =
+        ImmutableMap.<String, List<String>>builder()
+            .put("command", Collections.singletonList("echo 'hello world'"))
+            .build();
+
+    @Test
+    void associationDescriptionToResourceModelWithAllModelParametersPresent() {
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withDocumentVersion(DOCUMENT_VERSION)
+                .withAssociationName(ASSOCIATION_NAME)
+                .withParameters(PARAMETERS)
+                .withTargets(Collections.singletonList(
+                    new com.amazonaws.services.simplesystemsmanagement.model.Target()
+                        .withKey(TARGET_KEY)
+                        .withValues(TARGET_VALUE)))
+                .withScheduleExpression(SCHEDULE_EXPRESSION)
+                .withComplianceSeverity(COMPLIANCE_SEVERITY)
+                .withMaxConcurrency(MAX_CONCURRENCY)
+                .withMaxErrors(MAX_ERRORS)
+                .withOutputLocation(new com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation()
+                    .withS3Location(
+                        new com.amazonaws.services.simplesystemsmanagement.model.S3OutputLocation()
+                            .withOutputS3Region(S3_BUCKET_REGION)
+                            .withOutputS3BucketName(S3_BUCKET_NAME)
+                            .withOutputS3KeyPrefix(S3_KEY_PREFIX)))
+                .withAutomationTargetParameterName(AUTOMATION_TARGET_PARAMETER_NAME)
+                .withInstanceId(INSTANCE_ID)
+                // parameter below are not present in the ResourceModel, they should get ignored during conversion
+                .withAssociationVersion(ASSOCIATION_VERSION)
+                .withLastUpdateAssociationDate(LAST_UPDATE_ASSOCIATION_DATE)
+                .withLastExecutionDate(LAST_EXECUTION_DATE)
+                .withLastSuccessfulExecutionDate(LAST_SUCCESSFUL_EXECUTION_DATE);
+
+        final ResourceModel resultModel =
+            ResourceModelServiceModelConverter.associationDescriptionToResourceModel(associationDescription);
+
+        final ResourceModel expectedModel =
+            ResourceModel.builder()
+                .associationId(ASSOCIATION_ID)
+                .associationName(ASSOCIATION_NAME)
+                .name(DOCUMENT_NAME)
+                .documentVersion(DOCUMENT_VERSION)
+                .parameters(PARAMETERS)
+                .targets(TARGETS)
+                .scheduleExpression(SCHEDULE_EXPRESSION)
+                .complianceSeverity(COMPLIANCE_SEVERITY)
+                .maxConcurrency(MAX_CONCURRENCY)
+                .maxErrors(MAX_ERRORS)
+                .outputLocation(OUTPUT_LOCATION)
+                .automationTargetParameterName(AUTOMATION_TARGET_PARAMETER_NAME)
+                .instanceId(INSTANCE_ID)
+                .build();
+
+        assertThat(resultModel).isEqualTo(expectedModel);
+    }
+
+    @Test
+    void associationDescriptionToResourceModelWithNoTargetsAndNoParametersSet() {
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withAssociationName(ASSOCIATION_NAME)
+                .withScheduleExpression(SCHEDULE_EXPRESSION);
+
+        final ResourceModel resultModel =
+            ResourceModelServiceModelConverter.associationDescriptionToResourceModel(associationDescription);
+
+        final ResourceModel expectedModel =
+            ResourceModel.builder()
+                .associationId(ASSOCIATION_ID)
+                .associationName(ASSOCIATION_NAME)
+                .name(DOCUMENT_NAME)
+                .scheduleExpression(SCHEDULE_EXPRESSION)
+                .build();
+
+        assertThat(resultModel).isEqualTo(expectedModel);
+    }
+
+    @Test
+    void associationDescriptionToResourceModelWithEmptyTargetsAndParametersSet() {
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withAssociationName(ASSOCIATION_NAME)
+                .withScheduleExpression(SCHEDULE_EXPRESSION)
+                .withParameters(new HashMap<>())
+                .withTargets(Collections.emptyList());
+
+        final ResourceModel resultModel =
+            ResourceModelServiceModelConverter.associationDescriptionToResourceModel(associationDescription);
+
+        final ResourceModel expectedModel =
+            ResourceModel.builder()
+                .associationId(ASSOCIATION_ID)
+                .associationName(ASSOCIATION_NAME)
+                .name(DOCUMENT_NAME)
+                .scheduleExpression(SCHEDULE_EXPRESSION)
+                .build();
+
+        assertThat(resultModel).isEqualTo(expectedModel);
+    }
+
+    @Test
+    void associationDescriptionToResourceModelWithS3OutputLocationMissingFromInstanceAssociationOutputLocation() {
+        final AssociationDescription associationDescription =
+            new AssociationDescription()
+                .withAssociationId(ASSOCIATION_ID)
+                .withName(DOCUMENT_NAME)
+                .withAssociationName(ASSOCIATION_NAME)
+                .withScheduleExpression(SCHEDULE_EXPRESSION)
+                .withOutputLocation(new com.amazonaws.services.simplesystemsmanagement.model.InstanceAssociationOutputLocation());
+
+        final ResourceModel resultModel =
+            ResourceModelServiceModelConverter.associationDescriptionToResourceModel(associationDescription);
+
+        final ResourceModel expectedModel =
+            ResourceModel.builder()
+                .associationId(ASSOCIATION_ID)
+                .associationName(ASSOCIATION_NAME)
+                .name(DOCUMENT_NAME)
+                .scheduleExpression(SCHEDULE_EXPRESSION)
+                .build();
+
+        assertThat(resultModel).isEqualTo(expectedModel);
+    }
+}


### PR DESCRIPTION
*Description of changes:*
* Resource schema has been updated to correspond with SSM State Manager Service model.
* Added dependency on SSM Java SDK.
* All handlers except ListHandler implemented and tested.
* CreateHandler accepts `WaitForAssociationSuccess` parameter to indicate whether the resource creation signal should be sent after the association finishes its first execution successfully.
 * This still has to be implemented in UpdateHandler.

*Testing:*
* `cfn-cli generate`, `mvn package` succeed.
* Tested different operations using several requests via `sam local invoke TestEntrypoint --event create.json`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
