### PR TITLE
More verbose error handling to provide more exception details to cust…

### DIFF
--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/DeleteHandler.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/DeleteHandler.java
@@ -75,9 +75,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
             progressEvent.setStatus(OperationStatus.SUCCESS);
         } catch (Exception e) {
             final BaseHandlerException cfnException = exceptionTranslator.
-                translateFromServiceException(e,
-                    deleteAssociationRequest,
-                    Optional.ofNullable(deleteAssociationRequest.associationId()));
+                translateFromServiceException(e, deleteAssociationRequest, model);
 
             logger.log(cfnException.getCause().getMessage());
 

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/InProgressCreateHandler.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/InProgressCreateHandler.java
@@ -13,8 +13,6 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Optional;
-
 /**
  * Handles noninitial create requests for a given resource.
  */
@@ -79,7 +77,7 @@ public class InProgressCreateHandler extends BaseHandler<CallbackContext> {
 
         } catch (Exception e) {
             final BaseHandlerException cfnException = exceptionTranslator
-                .translateFromServiceException(e, describeAssociationRequest, Optional.of(associationId));
+                .translateFromServiceException(e, describeAssociationRequest, request.getDesiredResourceState());
 
             logger.log(cfnException.getCause().getMessage());
 

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/InitialCreateHandler.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/InitialCreateHandler.java
@@ -12,8 +12,6 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Optional;
-
 /**
  * Handles initial create requests for a given resource.
  */
@@ -81,7 +79,7 @@ public class InitialCreateHandler extends BaseHandler<CallbackContext> {
                     .associationDescription();
         } catch (Exception e) {
             final BaseHandlerException cfnException = exceptionTranslator
-                .translateFromServiceException(e, createAssociationRequest, Optional.empty());
+                .translateFromServiceException(e, createAssociationRequest, desiredModel);
 
             logger.log(cfnException.getCause().getMessage());
 

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/ReadHandler.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/ReadHandler.java
@@ -15,8 +15,6 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Optional;
-
 /**
  * Handles read requests for a given resource.
  */
@@ -86,7 +84,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
 
         } catch (Exception e) {
             final BaseHandlerException cfnException = exceptionTranslator
-                .translateFromServiceException(e, describeAssociationRequest, Optional.of(associationId));
+                .translateFromServiceException(e, describeAssociationRequest, requestModel);
 
             logger.log(cfnException.getCause().getMessage());
 

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/UpdateHandler.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/UpdateHandler.java
@@ -16,8 +16,6 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Optional;
-
 /**
  * Handles update requests on a given resource.
  */
@@ -92,7 +90,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
 
         } catch (Exception e) {
             final BaseHandlerException cfnException = exceptionTranslator
-                .translateFromServiceException(e, updateAssociationRequest, Optional.of(associationId));
+                .translateFromServiceException(e, updateAssociationRequest, requestModel);
 
             logger.log(cfnException.getCause().getMessage());
 

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/DeleteHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/DeleteHandlerTest.java
@@ -20,7 +20,6 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -213,13 +212,13 @@ class DeleteHandlerTest {
             exceptionTranslator.translateFromServiceException(
                 serviceException,
                 expectedDeleteAssociationRequest,
-                Optional.of(expectedDeleteAssociationRequest.associationId())))
+                model))
             .thenReturn(new CfnThrottlingException("DeleteAssociation", serviceException));
 
         Assertions.assertThrows(CfnThrottlingException.class, () -> {
             handler.handleRequest(proxy, request, null, logger);
         });
         verify(exceptionTranslator)
-            .translateFromServiceException(serviceException, expectedDeleteAssociationRequest, Optional.of(model.getAssociationId()));
+            .translateFromServiceException(serviceException, expectedDeleteAssociationRequest, model);
     }
 }

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InProgressCreateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InProgressCreateHandlerTest.java
@@ -23,7 +23,6 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -349,7 +348,7 @@ class InProgressCreateHandlerTest {
             exceptionTranslator.translateFromServiceException(
                 serviceException,
                 describeAssociationRequest,
-                Optional.of(describeAssociationRequest.associationId())))
+                model))
             .thenReturn(new CfnServiceInternalErrorException("DescribeAssociation", serviceException));
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -366,6 +365,6 @@ class InProgressCreateHandlerTest {
             handler.handleRequest(proxy, request, callbackContext, logger);
         });
         verify(exceptionTranslator)
-            .translateFromServiceException(serviceException, describeAssociationRequest, Optional.of(model.getAssociationId()));
+            .translateFromServiceException(serviceException, describeAssociationRequest, model);
     }
 }

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InitialCreateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InitialCreateHandlerTest.java
@@ -21,7 +21,6 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -213,13 +212,13 @@ class InitialCreateHandlerTest {
                 ArgumentMatchers.<Function<CreateAssociationRequest, CreateAssociationResponse>>any()))
             .thenThrow(serviceException);
 
-        when(exceptionTranslator.translateFromServiceException(serviceException, createAssociationRequest, Optional.empty()))
+        when(exceptionTranslator.translateFromServiceException(serviceException, createAssociationRequest, model))
             .thenReturn(new CfnServiceInternalErrorException("CreateAssociation", serviceException));
 
         Assertions.assertThrows(CfnServiceInternalErrorException.class, () -> {
             handler.handleRequest(proxy, request, null, logger);
         });
         verify(exceptionTranslator)
-            .translateFromServiceException(serviceException, createAssociationRequest, Optional.empty());
+            .translateFromServiceException(serviceException, createAssociationRequest, model);
     }
 }

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/ReadHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/ReadHandlerTest.java
@@ -21,7 +21,6 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -157,7 +156,7 @@ class ReadHandlerTest {
             exceptionTranslator.translateFromServiceException(
                 serviceException,
                 expectedDescribeAssociationRequest,
-                Optional.of(expectedDescribeAssociationRequest.associationId())))
+                model))
             .thenReturn(new CfnServiceInternalErrorException("DescribeAssociation", serviceException));
 
         Assertions.assertThrows(CfnServiceInternalErrorException.class, () -> {
@@ -167,7 +166,7 @@ class ReadHandlerTest {
             .translateFromServiceException(
                 serviceException,
                 expectedDescribeAssociationRequest,
-                Optional.of(expectedDescribeAssociationRequest.associationId()));
+                model);
         verify(logger).log(anyString());
     }
 }

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/UpdateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/UpdateHandlerTest.java
@@ -22,7 +22,6 @@ import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -193,7 +192,7 @@ class UpdateHandlerTest {
             exceptionTranslator.translateFromServiceException(
                 serviceException,
                 expectedUpdateAssociationRequest,
-                Optional.of(expectedUpdateAssociationRequest.associationId())))
+                desiredModel))
             .thenReturn(new CfnThrottlingException("UpdateAssociation", serviceException));
 
         Assertions.assertThrows(CfnThrottlingException.class, () -> {
@@ -203,6 +202,6 @@ class UpdateHandlerTest {
             .translateFromServiceException(
                 serviceException,
                 expectedUpdateAssociationRequest,
-                Optional.of(desiredModel.getAssociationId()));
+                desiredModel);
     }
 }


### PR DESCRIPTION
…omers

*Description of changes:*
* Changing constructors for all CfnExceptions to use more verbose constructors.
* ExceptionTranslator now takes in ResourceModel to complete the exception information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
