### PR TITLE
Parameter values length fix

### DIFF
--- a/aws-ssm-association/aws-ssm-association.json
+++ b/aws-ssm-association/aws-ssm-association.json
@@ -113,12 +113,7 @@
             "type": "object",
             "patternProperties": {
                 ".*{1,255}": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 65535
-                    }
+                    "$ref": "#/definitions/ParameterValues"
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
*Description of changes:* Service model validation does not validate for minLength=1 for parameter values, despite the constraints being in the model. Removing the constraints here so empty-string optional parameters could be passed in in the CFN templates.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
