### PR TITLE
InvalidRequestExceptions now contain exception messaging from the ser…

### DIFF
--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/ExceptionTranslator.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/ExceptionTranslator.java
@@ -74,7 +74,7 @@ public class ExceptionTranslator {
             || serviceException instanceof InvalidTargetException
             || serviceException instanceof UnsupportedPlatformTypeException) {
 
-            return new CfnInvalidRequestException(request.toString(), serviceException);
+            return new CfnInvalidRequestException(serviceException.getMessage(), serviceException);
         } else if (serviceException instanceof TooManyUpdatesException) {
 
             return new CfnThrottlingException(getClassNameWithoutRequestSuffix(request.getClass().getSimpleName()),

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/util/ExceptionTranslatorTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/util/ExceptionTranslatorTest.java
@@ -187,7 +187,7 @@ class ExceptionTranslatorTest {
                 model);
 
         assertTrue(cfnException instanceof CfnInvalidRequestException);
-        final String expectedMessage = String.format("Invalid request provided: %s", request.toString());
+        final String expectedMessage = String.format("Invalid request provided: %s", serviceException.getMessage());
         assertEquals(expectedMessage, cfnException.getMessage());
     }
 
@@ -204,7 +204,7 @@ class ExceptionTranslatorTest {
                 model);
 
         assertTrue(cfnException instanceof CfnInvalidRequestException);
-        final String expectedMessage = String.format("Invalid request provided: %s", request.toString());
+        final String expectedMessage = String.format("Invalid request provided: %s", serviceException.getMessage());
         assertEquals(expectedMessage, cfnException.getMessage());
     }
 
@@ -221,7 +221,7 @@ class ExceptionTranslatorTest {
                 model);
 
         assertTrue(cfnException instanceof CfnInvalidRequestException);
-        final String expectedMessage = String.format("Invalid request provided: %s", request.toString());
+        final String expectedMessage = String.format("Invalid request provided: %s", serviceException.getMessage());
         assertEquals(expectedMessage, cfnException.getMessage());
     }
 
@@ -238,7 +238,7 @@ class ExceptionTranslatorTest {
                 model);
 
         assertTrue(cfnException instanceof CfnInvalidRequestException);
-        final String expectedMessage = String.format("Invalid request provided: %s", request.toString());
+        final String expectedMessage = String.format("Invalid request provided: %s", serviceException.getMessage());
         assertEquals(expectedMessage, cfnException.getMessage());
     }
 


### PR DESCRIPTION
…vice

*Description of changes:*
* Adding service exception messaging to CfnInvalidRequestExceptions. This will make customer messaging clearer in cases of bad input.
* Ran unit tests and integration tests suite.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
