### PR TITLE
Call RemoveTags before AddTags

### DIFF
--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagUpdater.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagUpdater.java
@@ -42,8 +42,8 @@ public class TagUpdater {
         final List<Tag> tagsToAdd = getTagsToAdd(requestedTags, existingTags);
         final List<Tag> tagsToRemove = getTagsToRemove(requestedTags, existingTags);
 
-        tagClient.addTags(tagsToAdd, documentName, ssmClient, proxy);
         tagClient.removeTags(tagsToRemove, documentName, ssmClient, proxy);
+        tagClient.addTags(tagsToAdd, documentName, ssmClient, proxy);
     }
 
     private List<Tag> getTagsToAdd(List<Tag> requestedTags, List<Tag> existingTags) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
SSM RemoveTagsFromResource call takes tag keys to be removed as input.
SSM AddTagsToResource call takes tag keys and values to be added as input.

When a value for an existing Tag Key has to be updated, we need to call Remove first to remove the key with the old value. We then call AddTags to add the tag key with new value.
If we call Addtags to add the tag key with new value, then the Tag Key will be removed when RemoveTags is called subsequently.

This fix modifies the order of the calls so that RemoveTags is called first, AddTags is called second.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
