### PR TITLE
Add support for ApplyOnlyAtCronInterval attribute for AWS::SSM::Assoc…

### DIFF
--- a/aws-ssm-association/aws-ssm-association.json
+++ b/aws-ssm-association/aws-ssm-association.json
@@ -190,6 +190,9 @@
             "type": "integer",
             "minimum": 15,
             "maximum": 172800
+        },
+        "ApplyOnlyAtCronInterval": {
+            "type": "boolean"
         }
     },
     "required": [

--- a/aws-ssm-association/pom.xml
+++ b/aws-ssm-association/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ssm</artifactId>
-            <version>2.13.5</version>
+            <version>2.13.34</version>
         </dependency>
 
         <!-- https://github.com/awslabs/aws-cloudformation-rpdk-java-plugin/ -->

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/AssociationDescriptionTranslator.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/AssociationDescriptionTranslator.java
@@ -52,6 +52,7 @@ public class AssociationDescriptionTranslator {
 
         model.setAssociationId(association.associationId());
         model.setName(association.name());
+        model.setApplyOnlyAtCronInterval(association.applyOnlyAtCronInterval());
 
         simpleTypeValidator.getValidatedString(association.associationName())
             .ifPresent(model::setAssociationName);

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/request/CreateAssociationTranslator.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/request/CreateAssociationTranslator.java
@@ -49,7 +49,8 @@ public class CreateAssociationTranslator implements RequestTranslator<CreateAsso
     public CreateAssociationRequest resourceModelToRequest(final ResourceModel model) {
         final CreateAssociationRequest.Builder createAssociationRequestBuilder =
             CreateAssociationRequest.builder()
-                .name(model.getName());
+                .name(model.getName())
+                .applyOnlyAtCronInterval(model.getApplyOnlyAtCronInterval());
 
         simpleTypeValidator.getValidatedString(model.getAssociationName())
             .ifPresent(createAssociationRequestBuilder::associationName);

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/request/UpdateAssociationTranslator.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/request/UpdateAssociationTranslator.java
@@ -49,7 +49,8 @@ public class UpdateAssociationTranslator implements RequestTranslator<UpdateAsso
     public UpdateAssociationRequest resourceModelToRequest(final ResourceModel model) {
         final UpdateAssociationRequest.Builder updateAssociationRequestBuilder =
             UpdateAssociationRequest.builder()
-                .associationId(model.getAssociationId());
+                .associationId(model.getAssociationId())
+                .applyOnlyAtCronInterval(model.getApplyOnlyAtCronInterval());
 
         simpleTypeValidator.getValidatedString(model.getName())
             .ifPresent(updateAssociationRequestBuilder::name);

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/AssociationDescriptionTranslatorTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/AssociationDescriptionTranslatorTest.java
@@ -88,6 +88,7 @@ class AssociationDescriptionTranslatorTest {
                 .lastExecutionDate(LAST_EXECUTION_DATE)
                 .lastSuccessfulExecutionDate(LAST_SUCCESSFUL_EXECUTION_DATE)
                 .syncCompliance(SYNC_COMPLIANCE)
+                .applyOnlyAtCronInterval(true)
                 .build();
 
         final ResourceModel resultModel =
@@ -109,6 +110,7 @@ class AssociationDescriptionTranslatorTest {
                 .automationTargetParameterName(AUTOMATION_TARGET_PARAMETER_NAME)
                 .instanceId(INSTANCE_ID)
                 .syncCompliance(SYNC_COMPLIANCE)
+                .applyOnlyAtCronInterval(true)
                 .build();
 
         assertThat(resultModel).isEqualTo(expectedModel);

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/request/CreateAssociationTranslatorTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/request/CreateAssociationTranslatorTest.java
@@ -76,6 +76,7 @@ class CreateAssociationTranslatorTest {
                 .automationTargetParameterName(AUTOMATION_TARGET_PARAMETER_NAME)
                 .instanceId(INSTANCE_ID)
                 .syncCompliance(SYNC_COMPLIANCE)
+                .applyOnlyAtCronInterval(true)
                 .build();
 
         final CreateAssociationRequest createAssociationRequest =
@@ -96,6 +97,7 @@ class CreateAssociationTranslatorTest {
                 .automationTargetParameterName(AUTOMATION_TARGET_PARAMETER_NAME)
                 .instanceId(INSTANCE_ID)
                 .syncCompliance(SYNC_COMPLIANCE)
+                .applyOnlyAtCronInterval(true)
                 .build();
 
         assertThat(createAssociationRequest).isEqualTo(expectedRequest);

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/request/UpdateAssociationTranslatorTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/request/UpdateAssociationTranslatorTest.java
@@ -76,6 +76,7 @@ class UpdateAssociationTranslatorTest {
                 .outputLocation(MODEL_OUTPUT_LOCATION)
                 .automationTargetParameterName(AUTOMATION_TARGET_PARAMETER_NAME)
                 .syncCompliance(SYNC_COMPLIANCE)
+                .applyOnlyAtCronInterval(true)
                 .build();
 
         final UpdateAssociationRequest createAssociationRequest =
@@ -96,6 +97,7 @@ class UpdateAssociationTranslatorTest {
                 .outputLocation(SERVICE_OUTPUT_LOCATION)
                 .automationTargetParameterName(AUTOMATION_TARGET_PARAMETER_NAME)
                 .syncCompliance(SYNC_COMPLIANCE)
+                .applyOnlyAtCronInterval(true)
                 .build();
 
         assertThat(createAssociationRequest).isEqualTo(expectedRequest);


### PR DESCRIPTION


Add support for ApplyOnlyAtCronInterval attribute for AWS::SSM::Association resource

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
