### PR TITLE
AWS::SSM::Association: introducing InProgressEventCreator and refacto…

### DIFF
--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/CreateHandler.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/CreateHandler.java
@@ -14,35 +14,34 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
  */
 public class CreateHandler extends BaseHandler<CallbackContext> {
 
-    private static final int CALLBACK_DELAY_SECONDS = 15;
     private static final SsmClient SSM_CLIENT = SsmClientBuilder.getClient();
 
     private final BaseHandler<CallbackContext> initialCreateHandler;
-    private final BaseHandler<CallbackContext> inProgressCreateHandler;
+    private final BaseHandler<CallbackContext> inProgressHandler;
     private final ResourceHandlerRequestToStringConverter requestToStringConverter;
 
     /**
      * Empty constructor used by wrapper classes.
      */
     CreateHandler() {
-        initialCreateHandler = new InitialCreateHandler(CALLBACK_DELAY_SECONDS, SSM_CLIENT);
-        inProgressCreateHandler = new InProgressCreateHandler(CALLBACK_DELAY_SECONDS, SSM_CLIENT);
+        initialCreateHandler = new InitialCreateHandler(SSM_CLIENT);
+        inProgressHandler = new InProgressHandler(SSM_CLIENT);
         requestToStringConverter = new ResourceHandlerRequestToStringConverter(new ResourceModelToStringConverter());
     }
 
     /**
      * Used for unit tests.
      *
-     * @param initialCreateHandler Concrete implementation of BaseCreateHandler used to handle first Create requests.
-     * @param inProgressCreateHandler Concrete implementation of BaseCreateHandler used to handle noninitial Create requests.
+     * @param initialCreateHandler Concrete implementation of BaseHandler used to handle first Create requests.
+     * @param inProgressHandler Concrete implementation of BaseHandler used to handle in-progress requests.
      * @param requestToStringConverter ResourceHandlerRequestToStringConverter used to convert requests to Strings.
      */
     CreateHandler(final BaseHandler<CallbackContext> initialCreateHandler,
-                  final BaseHandler<CallbackContext> inProgressCreateHandler,
+                  final BaseHandler<CallbackContext> inProgressHandler,
                   final ResourceHandlerRequestToStringConverter requestToStringConverter) {
 
         this.initialCreateHandler = initialCreateHandler;
-        this.inProgressCreateHandler = inProgressCreateHandler;
+        this.inProgressHandler = inProgressHandler;
         this.requestToStringConverter = requestToStringConverter;
     }
 
@@ -58,7 +57,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         if (callbackContext == null) {
             return initialCreateHandler.handleRequest(proxy, request, callbackContext, logger);
         } else {
-            return inProgressCreateHandler.handleRequest(proxy, request, callbackContext, logger);
+            return inProgressHandler.handleRequest(proxy, request, callbackContext, logger);
         }
     }
 }

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/InProgressEventCreator.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/InProgressEventCreator.java
@@ -1,0 +1,52 @@
+package com.amazonaws.ssm.association;
+
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+
+/**
+ * Creates InProgress {@link ProgressEvent} objects for use in handlers requiring progress chaining.
+ */
+public class InProgressEventCreator {
+
+    /**
+     * How many seconds later should the callback happen for the ProgressEvent created here.
+     */
+    private static final int CALLBACK_DELAY_SECONDS = 15;
+
+    /**
+     * Provides the next {@link OperationStatus#IN_PROGRESS} status {@link ProgressEvent} object with a callback context.
+     * If the provided remaining timeout is smaller than the {@link InProgressEventCreator#CALLBACK_DELAY_SECONDS}, we:
+     *
+     *      1. Set the remaining timeout on the callback context to 0. This will be the last callback before timeout.
+     *      2. Set the callback delay on the ProgressEvent to the remaining timeout (instead of
+     *      {@link InProgressEventCreator#CALLBACK_DELAY_SECONDS}, in order to honor the customer timeout.
+     *
+     * @param remainingTimeoutSeconds Number of seconds remaining before progress chaining timeout.
+     * @param latestModel Resource model to use for the ProgressEvent.
+     *
+     * @return ProgressEvent with the latest resource model and updated remaining timeout values.
+     */
+    public ProgressEvent<ResourceModel, CallbackContext> nextInProgressEvent(final int remainingTimeoutSeconds,
+                                                                             final ResourceModel latestModel) {
+        final String associationId = latestModel.getAssociationId();
+
+        if (remainingTimeoutSeconds < CALLBACK_DELAY_SECONDS) {
+
+            return ProgressEvent.defaultInProgressHandler(
+                CallbackContext.builder()
+                    .remainingTimeoutSeconds(0)
+                    .associationId(associationId)
+                    .build(),
+                remainingTimeoutSeconds,
+                latestModel);
+        } else {
+            return ProgressEvent.defaultInProgressHandler(
+                CallbackContext.builder()
+                    .remainingTimeoutSeconds(remainingTimeoutSeconds - CALLBACK_DELAY_SECONDS)
+                    .associationId(associationId)
+                    .build(),
+                CALLBACK_DELAY_SECONDS,
+                latestModel);
+        }
+    }
+}

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/CreateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/CreateHandlerTest.java
@@ -34,7 +34,7 @@ class CreateHandlerTest {
     @Mock
     private BaseHandler<CallbackContext> initialCreateHandler;
     @Mock
-    private BaseHandler<CallbackContext> inProgressCreateHandler;
+    private BaseHandler<CallbackContext> inProgressHandler;
     @Mock
     private ResourceHandlerRequestToStringConverter requestToStringConverter;
 
@@ -42,7 +42,7 @@ class CreateHandlerTest {
     void setUp() {
         when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
 
-        handler = new CreateHandler(initialCreateHandler, inProgressCreateHandler, requestToStringConverter);
+        handler = new CreateHandler(initialCreateHandler, inProgressHandler, requestToStringConverter);
     }
 
     @Test
@@ -68,7 +68,7 @@ class CreateHandlerTest {
 
         assertThat(response).isEqualTo(expectedProgressEvent);
         verify(initialCreateHandler).handleRequest(proxy, request, callbackContext, logger);
-        verifyZeroInteractions(inProgressCreateHandler);
+        verifyZeroInteractions(inProgressHandler);
     }
 
     @Test
@@ -87,13 +87,13 @@ class CreateHandlerTest {
         final ProgressEvent<ResourceModel, CallbackContext> expectedProgressEvent =
             ProgressEvent.progress(model, callbackContext);
 
-        when(inProgressCreateHandler.handleRequest(proxy, request, callbackContext, logger)).thenReturn(expectedProgressEvent);
+        when(inProgressHandler.handleRequest(proxy, request, callbackContext, logger)).thenReturn(expectedProgressEvent);
 
         final ProgressEvent<ResourceModel, CallbackContext> response
             = handler.handleRequest(proxy, request, callbackContext, logger);
 
         assertThat(response).isEqualTo(expectedProgressEvent);
-        verify(inProgressCreateHandler).handleRequest(proxy, request, callbackContext, logger);
+        verify(inProgressHandler).handleRequest(proxy, request, callbackContext, logger);
         verifyZeroInteractions(initialCreateHandler);
     }
 

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/CreateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/CreateHandlerTest.java
@@ -40,13 +40,18 @@ class CreateHandlerTest {
 
     @BeforeEach
     void setUp() {
-        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
-
         handler = new CreateHandler(initialCreateHandler, inProgressHandler, requestToStringConverter);
     }
 
     @Test
+    void defaultConstructorWorks() {
+        new CreateHandler();
+    }
+
+    @Test
     void handleRequestWithNoCallbackContextInvokesInitialHandler() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
+
         final ResourceModel model = ResourceModel.builder()
             .name(DOCUMENT_NAME)
             .scheduleExpression(SCHEDULE_EXPRESSION)
@@ -73,6 +78,8 @@ class CreateHandlerTest {
 
     @Test
     void handleRequestWithCallbackContextInvokesInProgressHandler() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
+
         final ResourceModel model = ResourceModel.builder()
             .name(DOCUMENT_NAME)
             .scheduleExpression(SCHEDULE_EXPRESSION)
@@ -99,6 +106,8 @@ class CreateHandlerTest {
 
     @Test
     void handleRequestLogsWithRequestConverter() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
+
         final ResourceModel model = ResourceModel.builder().build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/DeleteHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/DeleteHandlerTest.java
@@ -52,13 +52,17 @@ class DeleteHandlerTest {
 
     @BeforeEach
     void setup() {
-        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
-
         handler = new DeleteHandler(exceptionTranslator, requestToStringConverter);
     }
 
     @Test
+    void defaultConstructorWorks() {
+        new DeleteHandler();
+    }
+
+    @Test
     void handleRequestWithAssociationId() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
         final ResourceModel model = ResourceModel.builder()
             .associationId(ASSOCIATION_ID)
             .build();
@@ -92,6 +96,7 @@ class DeleteHandlerTest {
 
     @Test
     void handleRequestWithInstanceIdAndDocumentName() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
         final ResourceModel model = ResourceModel.builder()
             .instanceId(INSTANCE_ID)
             .name(DOCUMENT_NAME)
@@ -127,6 +132,7 @@ class DeleteHandlerTest {
 
     @Test
     void handleRequestWithNoRequiredParametersPresent() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
         final ResourceModel model = ResourceModel.builder()
             .build();
 
@@ -152,6 +158,7 @@ class DeleteHandlerTest {
 
     @Test
     void handleRequestWhenAssociationDoesNotExist() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
         final ResourceModel model = ResourceModel.builder()
             .associationId(ASSOCIATION_ID)
             .build();
@@ -192,6 +199,7 @@ class DeleteHandlerTest {
 
     @Test
     void handleRequestThrowsTranslatedServiceException() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
         final ResourceModel model = ResourceModel.builder()
             .associationId(ASSOCIATION_ID)
             .build();
@@ -229,6 +237,7 @@ class DeleteHandlerTest {
 
     @Test
     void handleRequestLogsWithRequestConverter() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
         final ResourceModel model = ResourceModel.builder().build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InProgressEventCreatorTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InProgressEventCreatorTest.java
@@ -1,0 +1,59 @@
+package com.amazonaws.ssm.association;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InProgressEventCreatorTest {
+
+    private static final int CALLBACK_DELAY_SECONDS = 15;
+
+    private final InProgressEventCreator inProgressEventCreator = new InProgressEventCreator();
+
+    @Test
+    void nextInProgressEventWithRemainingTimeoutGreaterThanCallbackDelayDecreasesRemainingTimeByCallbackDelay() {
+        final int remainingTimeoutSeconds = 35;
+        final ResourceModel latestModel = ResourceModel.builder()
+            .associationId(TestsInputs.ASSOCIATION_ID)
+            .name(TestsInputs.DOCUMENT_NAME)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> nextInProgressEvent =
+            inProgressEventCreator.nextInProgressEvent(remainingTimeoutSeconds, latestModel);
+
+        final CallbackContext expectedCallbackContext =
+            CallbackContext.builder()
+                .remainingTimeoutSeconds(remainingTimeoutSeconds - CALLBACK_DELAY_SECONDS)
+                .associationId(latestModel.getAssociationId())
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> expectedProgressEvent =
+            ProgressEvent.defaultInProgressHandler(expectedCallbackContext, CALLBACK_DELAY_SECONDS, latestModel);
+
+        assertThat(nextInProgressEvent).isEqualTo(expectedProgressEvent);
+    }
+
+    @Test
+    void nextInProgressEventWithRemainingTimeoutSmallerThanCallbackDelayReturnsRemainingTimeAsZeroAndCallbackAsRemainingTime() {
+        final int remainingTimeoutSeconds = 5;
+        final ResourceModel latestModel = ResourceModel.builder()
+            .associationId(TestsInputs.ASSOCIATION_ID)
+            .name(TestsInputs.DOCUMENT_NAME)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> nextInProgressEvent =
+            inProgressEventCreator.nextInProgressEvent(remainingTimeoutSeconds, latestModel);
+
+        final CallbackContext expectedCallbackContext =
+            CallbackContext.builder()
+                .remainingTimeoutSeconds(0)
+                .associationId(latestModel.getAssociationId())
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> expectedProgressEvent =
+            ProgressEvent.defaultInProgressHandler(expectedCallbackContext, remainingTimeoutSeconds, latestModel);
+
+        assertThat(nextInProgressEvent).isEqualTo(expectedProgressEvent);
+    }
+}

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InProgressHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InProgressHandlerTest.java
@@ -70,6 +70,11 @@ class InProgressHandlerTest {
     }
 
     @Test
+    void defaultConstructorWorks() {
+        new InProgressHandler(ssmClient);
+    }
+
+    @Test
     public void handleInProgressRequestWithTimeoutRemainingAndAssociationSuccessStatus() {
         final DescribeAssociationRequest describeAssociationRequest =
             DescribeAssociationRequest.builder()

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InitialCreateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InitialCreateHandlerTest.java
@@ -62,6 +62,11 @@ class InitialCreateHandlerTest {
     }
 
     @Test
+    void defaultConstructorWorks() {
+        new InitialCreateHandler(ssmClient);
+    }
+
+    @Test
     void handleInitialCreateRequestWithNoWaitForSuccess() {
         final ResourceModel model = ResourceModel.builder()
             .name(DOCUMENT_NAME)

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InitialCreateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InitialCreateHandlerTest.java
@@ -32,8 +32,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class InitialCreateHandlerTest {
 
-    private static final int CALLBACK_DELAY_SECONDS = 15;
-
     private static final String DOCUMENT_NAME = "TestDocument";
     private static final String SCHEDULE_EXPRESSION = "rate(30)";
     private static final String ASSOCIATION_ID = "test-12345-associationId";
@@ -51,14 +49,16 @@ class InitialCreateHandlerTest {
     private AssociationDescriptionTranslator associationDescriptionTranslator;
     @Mock
     private ExceptionTranslator exceptionTranslator;
+    @Mock
+    private InProgressEventCreator inProgressEventCreator;
 
     @BeforeEach
     void setUp() {
-        handler = new InitialCreateHandler(CALLBACK_DELAY_SECONDS,
-            ssmClient,
+        handler = new InitialCreateHandler(ssmClient,
             createAssociationTranslator,
             associationDescriptionTranslator,
-            exceptionTranslator);
+            exceptionTranslator,
+            inProgressEventCreator);
     }
 
     @Test
@@ -161,20 +161,25 @@ class InitialCreateHandlerTest {
         when(associationDescriptionTranslator.associationDescriptionToResourceModel(associationDescription))
             .thenReturn(expectedModel);
 
-        final ProgressEvent<ResourceModel, CallbackContext> response
-            = handler.handleRequest(proxy, request, null, logger);
-
+        final int callbackDelaySeconds = 15;
         final CallbackContext expectedCallbackContext =
             CallbackContext.builder()
-                .remainingTimeoutSeconds(waitForSuccessTimeoutSeconds - CALLBACK_DELAY_SECONDS)
+                .remainingTimeoutSeconds(waitForSuccessTimeoutSeconds - callbackDelaySeconds)
                 .associationId(expectedModel.getAssociationId())
                 .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> expectedProgressEvent =
-            ProgressEvent.defaultInProgressHandler(expectedCallbackContext, CALLBACK_DELAY_SECONDS, expectedModel);
+            ProgressEvent.defaultInProgressHandler(expectedCallbackContext, callbackDelaySeconds, expectedModel);
+
+        when(inProgressEventCreator.nextInProgressEvent(waitForSuccessTimeoutSeconds, expectedModel))
+            .thenReturn(expectedProgressEvent);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
 
         assertThat(response).isEqualTo(expectedProgressEvent);
         verifyZeroInteractions(exceptionTranslator);
+        verify(inProgressEventCreator).nextInProgressEvent(waitForSuccessTimeoutSeconds, expectedModel);
     }
 
     @Test

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/ReadHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/ReadHandlerTest.java
@@ -55,13 +55,18 @@ class ReadHandlerTest {
 
     @BeforeEach
     void setup() {
-        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
-
         handler = new ReadHandler(associationDescriptionTranslator, exceptionTranslator, requestToStringConverter);
     }
 
     @Test
+    void defaultConstructorWorks() {
+        new ReadHandler();
+    }
+
+    @Test
     void handleRequestWithAssociationId() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
+
         final ResourceModel model = ResourceModel.builder()
             .associationId(ASSOCIATION_ID)
             .build();
@@ -110,6 +115,8 @@ class ReadHandlerTest {
 
     @Test
     void handleRequestWithNoAssociationId() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
+
         final ResourceModel model = ResourceModel.builder()
             .build();
 
@@ -135,6 +142,8 @@ class ReadHandlerTest {
 
     @Test
     void handleRequestThrowsTranslatedServiceException() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
+
         final ResourceModel model = ResourceModel.builder()
             .associationId(ASSOCIATION_ID)
             .build();
@@ -176,6 +185,8 @@ class ReadHandlerTest {
 
     @Test
     void handleRequestLogsWithRequestConverter() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
+
         final ResourceModel model = ResourceModel.builder().build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/UpdateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/UpdateHandlerTest.java
@@ -223,7 +223,7 @@ class UpdateHandlerTest {
     @Test
     void handleRequestLogsWithRequestConverter() {
         when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
-        
+
         final ResourceModel model = ResourceModel.builder().build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/UpdateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/UpdateHandlerTest.java
@@ -68,6 +68,11 @@ class UpdateHandlerTest {
     }
 
     @Test
+    void defaultConstructorWorks() {
+        new UpdateHandler();
+    }
+
+    @Test
     void handleRequestWithAssociationIdPresent() {
         final ResourceModel.ResourceModelBuilder resourceModelBuilder =
             ResourceModel.builder()

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/UpdateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/UpdateHandlerTest.java
@@ -59,8 +59,6 @@ class UpdateHandlerTest {
 
     @BeforeEach
     void setup() {
-        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
-
         handler = new UpdateHandler(updateAssociationTranslator,
             associationDescriptionTranslator,
             exceptionTranslator,
@@ -74,6 +72,8 @@ class UpdateHandlerTest {
 
     @Test
     void handleRequestWithAssociationIdPresent() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
+
         final ResourceModel.ResourceModelBuilder resourceModelBuilder =
             ResourceModel.builder()
                 .associationId(ASSOCIATION_ID)
@@ -133,6 +133,8 @@ class UpdateHandlerTest {
 
     @Test
     void handleRequestWithNoAssociationId() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
+
         final ResourceModel desiredModel = ResourceModel.builder()
             .associationName(NEW_ASSOCIATION_NAME)
             .build();
@@ -165,6 +167,8 @@ class UpdateHandlerTest {
 
     @Test
     void handleRequestThrowsTranslatedServiceException() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
+
         final ResourceModel.ResourceModelBuilder resourceModelBuilder =
             ResourceModel.builder()
                 .associationId(ASSOCIATION_ID)
@@ -218,6 +222,8 @@ class UpdateHandlerTest {
 
     @Test
     void handleRequestLogsWithRequestConverter() {
+        when(requestToStringConverter.convert(any())).thenReturn(LOGGED_RESOURCE_HANDLER_REQUEST);
+        
         final ResourceModel model = ResourceModel.builder().build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()


### PR DESCRIPTION
…ring Create progress chaining; setting up for adding chaining to Update

*Description of changes:*
* Adding InProgressEventCreator to handle the logic of creating InProgress events. Update handler will also be relying on this once progress chaining is added there.
* Handlers rely on InProgressEventCreator.
* Added default constructor unit tests to make Jacoco pass line coverage.

*Testing:* Unit + integration tests suites succeeded.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
