### PR TITLE
remove ContentAsString attribute and support text content in Content attribute

### DIFF
--- a/aws-ssm-document/.rpdk-config
+++ b/aws-ssm-document/.rpdk-config
@@ -10,6 +10,7 @@
             "amazonaws",
             "ssm",
             "document"
-        ]
+        ],
+        "protocolVersion": "2.0.0"
     }
 }

--- a/aws-ssm-document/aws-ssm-document.json
+++ b/aws-ssm-document/aws-ssm-document.json
@@ -108,13 +108,11 @@
     },
     "properties": {
         "Content": {
-            "description": "The content for the Systems Manager document in JSON or YAML format. Use ContentAsString property if you wish to provide the content as String. Only one of Content or ContentAsString property has to be used but not both.",
-            "type": "object",
-            "minLength": 1
-        },
-        "ContentAsString": {
-            "description": "The content in the Systems Manager document as String. This could be an escaped JSON or just plain text depending on the type of Document. Only one of Content or ContentAsString property has to be used but not both.",
-            "type": "string",
+            "description": "The content for the Systems Manager document in JSON, YAML or String format.",
+            "type": [
+                "object",
+                "string"
+            ],
             "minLength": 1
         },
         "Attachments": {

--- a/aws-ssm-document/pom.xml
+++ b/aws-ssm-document/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.3</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/CallbackContext.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/CallbackContext.java
@@ -2,17 +2,26 @@ package com.amazonaws.ssm.document;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @Builder
 @JsonDeserialize(builder = CallbackContext.CallbackContextBuilder.class)
+@EqualsAndHashCode
 public class CallbackContext {
 
+    /**
+     * Boolean that tells whether the create operation on resource started.
+     */
     private Boolean createDocumentStarted;
 
+    /**
+     * Boolean that tells whether the operation on resource started.
+     */
     private Boolean eventStarted;
 
     private Integer stabilizationRetriesRemaining;
@@ -20,5 +29,9 @@ public class CallbackContext {
     @JsonIgnore
     public void decrementStabilizationRetriesRemaining() {
         stabilizationRetriesRemaining--;
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static class CallbackContextBuilder {
     }
 }

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/CreateHandler.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/CreateHandler.java
@@ -59,7 +59,6 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         final CallbackContext context = callbackContext == null ? CallbackContext.builder().build() : callbackContext;
         final ResourceModel model = request.getDesiredResourceState();
 
-        logger.log(context.toString());
         if (context.getCreateDocumentStarted() != null) {
             return updateProgress(model, context, ssmClient, proxy, logger);
         }

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/CreateHandler.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/CreateHandler.java
@@ -59,6 +59,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         final CallbackContext context = callbackContext == null ? CallbackContext.builder().build() : callbackContext;
         final ResourceModel model = request.getDesiredResourceState();
 
+        logger.log(context.toString());
         if (context.getCreateDocumentStarted() != null) {
             return updateProgress(model, context, ssmClient, proxy, logger);
         }

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentModelTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentModelTranslator.java
@@ -65,7 +65,7 @@ class DocumentModelTranslator {
             documentName = model.getName();
         }
 
-        final String documentContent = processDocumentContent(model.getContent(), model.getContentAsString());
+        final String documentContent = processDocumentContent(model.getContent());
 
         return CreateDocumentRequest.builder()
                 .name(documentName)
@@ -90,7 +90,7 @@ class DocumentModelTranslator {
     }
 
     UpdateDocumentRequest generateUpdateDocumentRequest(@NonNull final ResourceModel model) {
-        final String documentContent = processDocumentContent(model.getContent(), model.getContentAsString());
+        final String documentContent = processDocumentContent(model.getContent());
 
         return UpdateDocumentRequest.builder()
                 .name(model.getName())
@@ -156,12 +156,16 @@ class DocumentModelTranslator {
         return Optional.of(stackName);
     }
 
-    private String processDocumentContent(final Map<String, Object> jsonContent, final String contentAsString) {
-        try {
-            return jsonContent != null ? OBJECT_MAPPER.writeValueAsString(jsonContent) : contentAsString;
-        } catch (final JsonProcessingException e) {
-            throw new InvalidDocumentContentException("Document Content is not valid", e);
+    private String processDocumentContent(final Object content) {
+        if (content instanceof Map) {
+            try {
+                return OBJECT_MAPPER.writeValueAsString(content);
+            } catch (final JsonProcessingException e) {
+                throw new InvalidDocumentContentException("Document Content is not valid", e);
+            }
         }
+
+        return (String)content;
     }
 
     private List<Tag> translateTags(@Nullable final Map<String, String> tags) {

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
@@ -28,7 +28,7 @@ class DocumentResponseModelTranslator {
                 .documentFormat(response.documentFormatAsString())
                 .documentType(response.documentTypeAsString())
                 .documentVersion(response.documentVersion())
-                .contentAsString(response.content())
+                .content(response.content())
                 .requires(translateRequires(response))
                 .attachmentsContent(translateAttachments(response))
                 .build();

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/CallbackContextTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/CallbackContextTest.java
@@ -1,0 +1,23 @@
+package com.amazonaws.ssm.document;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CallbackContextTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    public void testSerializeAndDeserialize() throws JsonProcessingException {
+        final CallbackContext context = CallbackContext.builder()
+            .stabilizationRetriesRemaining(30)
+            .createDocumentStarted(false)
+            .eventStarted(true)
+            .build();
+
+        final String serializedText = OBJECT_MAPPER.writeValueAsString(context);
+
+        Assertions.assertEquals(context, OBJECT_MAPPER.readValue(serializedText, CallbackContext.class));
+    }
+}

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentModelTranslatorTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentModelTranslatorTest.java
@@ -231,7 +231,6 @@ public class DocumentModelTranslatorTest {
     @Test
     public void testGenerateCreateDocumentRequest_ContentJsonIsProvided_verifyResult() {
         final ResourceModel resourceModel = createResourceModel();
-        resourceModel.setContentAsString(null);
         resourceModel.setContent(SAMPLE_DOCUMENT_JSON_CONTENT);
 
         final CreateDocumentRequest expectedRequest = CreateDocumentRequest.builder()
@@ -318,7 +317,6 @@ public class DocumentModelTranslatorTest {
     @Test
     public void testGenerateUpdateDocumentRequest_ContentJsonIsProvided_verifyResult() {
         final ResourceModel resourceModel = createResourceModel();
-        resourceModel.setContentAsString(null);
         resourceModel.setContent(SAMPLE_DOCUMENT_JSON_CONTENT);
 
         final UpdateDocumentRequest expectedRequest = UpdateDocumentRequest.builder()
@@ -355,7 +353,7 @@ public class DocumentModelTranslatorTest {
     private ResourceModel createResourceModel() {
         return ResourceModel.builder()
                 .name(SAMPLE_DOCUMENT_NAME)
-                .contentAsString(SAMPLE_DOCUMENT_CONTENT)
+                .content(SAMPLE_DOCUMENT_CONTENT)
                 .versionName(SAMPLE_VERSION_NAME)
                 .documentFormat(SAMPLE_DOCUMENT_FORMAT)
                 .documentType(SAMPLE_DOCUMENT_TYPE)

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentResponseModelTranslatorTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentResponseModelTranslatorTest.java
@@ -182,7 +182,7 @@ public class DocumentResponseModelTranslatorTest {
     private ResourceModel createResourceModelWithAllAttributes() {
         return ResourceModel.builder()
                 .name(SAMPLE_DOCUMENT_NAME)
-                .contentAsString(SAMPLE_DOCUMENT_CONTENT)
+                .content(SAMPLE_DOCUMENT_CONTENT)
                 .documentVersion(SAMPLE_DOCUMENT_VERSION)
                 .versionName(SAMPLE_VERSION_NAME)
                 .documentFormat(SAMPLE_DOCUMENT_FORMAT)


### PR DESCRIPTION
remove ContentAsString attribute and support text content in Content attribute

*Issue #, if available:*

*Description of changes:*
Upgrade to RPDK2.0

Document resource provider supported both JSON and String content in the Content attribute of cloudformation template. To support backward compatibility and with RPDK 2.0 supporting multiple data types for an attribute, Content attribute in Document Resource Provider is modified to support both Object types and String types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
