### PR TITLE
Update to RPDK2.0 and enable end-to-end test for AWS::SSM::Maintenanc…

### DIFF
--- a/aws-ssm-maintenancewindowtask/.rpdk-config
+++ b/aws-ssm-maintenancewindowtask/.rpdk-config
@@ -11,6 +11,7 @@
             "ssm",
             "maintenancewindowtask"
         ],
-        "codegen_template_path": "default"
+        "codegen_template_path": "default",
+        "protocolVersion": "2.0.0"
     }
 }

--- a/aws-ssm-maintenancewindowtask/pom.xml
+++ b/aws-ssm-maintenancewindowtask/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.3</version>
+            <version>2.0.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,6 +20,11 @@ phases:
       - cd "$CODEBUILD_SRC_DIR"
       - cd aws-ssm-parameter
       - mvn clean verify --no-transfer-progress
+      # end-to-end test child repo for aws-ssm-maintenancewindowtask(s)
+      - cd "$CODEBUILD_SRC_DIR"
+      - cd aws-ssm-maintenancewindowtask
+      - mvn clean verify --no-transfer-progress
     finally:
       - cat "$CODEBUILD_SRC_DIR/aws-ssm-association/rpdk.log"
       - cat "$CODEBUILD_SRC_DIR/aws-ssm-parameter/rpdk.log"
+      - cat "$CODEBUILD_SRC_DIR/aws-ssm-maintenancewindowtask/rpdk.log"


### PR DESCRIPTION
…eWindowTask

Upgrading AWS::SSM::MaintenanceWindowTask to RPDK 2.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
