### PR TITLE
remove AttachmentsContent attribute since array is not a supported type

### DIFF
--- a/aws-ssm-document/aws-ssm-document.json
+++ b/aws-ssm-document/aws-ssm-document.json
@@ -151,9 +151,7 @@
         },
         "DocumentVersion": {
             "description": "The latest version number of document",
-            "type": "string",
-            "pattern": "([$]LATEST|[$]DEFAULT|^[1-9][0-9]*$)",
-            "maxLength": 8
+            "type": "string"
         }
     },
     "additionalProperties": false,

--- a/aws-ssm-document/aws-ssm-document.json
+++ b/aws-ssm-document/aws-ssm-document.json
@@ -73,37 +73,6 @@
                 }
             },
             "additionalProperties": false
-        },
-        "AttachmentContent": {
-            "type": "object",
-            "properties": {
-                "Name": {
-                    "description": "The name of an attachment.",
-                    "type": "string",
-                    "pattern": "^[a-zA-Z0-9_\\-.]{3,128}$"
-                },
-                "Size": {
-                    "description": "The size of an attachment in bytes.",
-                    "type": "integer"
-                },
-                "Hash": {
-                    "description": "The cryptographic hash value of the document content.",
-                    "type": "string",
-                    "maxLength": 256
-                },
-                "HashType": {
-                    "description": "The hash algorithm used to calculate the hash value.",
-                    "type": "string",
-                    "enum": [
-                        "Sha256"
-                    ]
-                },
-                "Url": {
-                    "description": "The URL location of the attachment content.",
-                    "type": "string"
-                }
-            },
-            "additionalProperties": false
         }
     },
     "properties": {
@@ -181,17 +150,10 @@
             "minItems": 1
         },
         "DocumentVersion": {
-            "description": "The version of the document that you want to update.",
+            "description": "The latest version number of document",
             "type": "string",
             "pattern": "([$]LATEST|[$]DEFAULT|^[1-9][0-9]*$)",
             "maxLength": 8
-        },
-        "AttachmentsContent": {
-            "description": "A description of the document attachments, including names, locations, sizes, etc.",
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/AttachmentContent"
-            }
         }
     },
     "additionalProperties": false,
@@ -201,23 +163,10 @@
         "/properties/DocumentType"
     ],
     "readOnlyProperties": [
-        "/properties/DocumentVersion",
-        "/properties/AttachmentsContent"
+        "/properties/DocumentVersion"
     ],
     "primaryIdentifier": [
         "/properties/Name"
-    ],
-    "oneOf": [
-        {
-            "required": [
-                "Content"
-            ]
-        },
-        {
-            "required": [
-                "ContentAsString"
-            ]
-        }
     ],
     "handlers": {
         "create": {

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
@@ -30,7 +30,6 @@ class DocumentResponseModelTranslator {
                 .documentVersion(response.documentVersion())
                 .content(response.content())
                 .requires(translateRequires(response))
-                .attachmentsContent(translateAttachments(response))
                 .build();
 
         final ResourceStatus state = translateStatus(response.status());
@@ -70,27 +69,6 @@ class DocumentResponseModelTranslator {
                 documentRequires -> DocumentRequires.builder()
                         .name(documentRequires.name())
                         .version(documentRequires.version())
-                        .build())
-                .collect(Collectors.toList());
-    }
-
-    private List<AttachmentContent> translateAttachments(final GetDocumentResponse response) {
-        if (!response.hasAttachmentsContent()) {
-            return null;
-        }
-
-        final List<software.amazon.awssdk.services.ssm.model.AttachmentContent> attachmentContents = response.attachmentsContent();
-        if (CollectionUtils.isEmpty(attachmentContents)) {
-            return null;
-        }
-
-        return attachmentContents.stream().map(
-                attachmentContent -> AttachmentContent.builder()
-                        .name(attachmentContent.name())
-                        .hash(attachmentContent.hash())
-                        .hashType(attachmentContent.hashTypeAsString())
-                        .size(attachmentContent.size().intValue())
-                        .url(attachmentContent.url())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentResponseModelTranslatorTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentResponseModelTranslatorTest.java
@@ -21,10 +21,7 @@ public class DocumentResponseModelTranslatorTest {
             Tag.builder().key("tagKey1").value("tagValue1").build(),
             Tag.builder().key("tagKey2").value("tagValue2").build()
     );
-    private static final List<AttachmentContent> SAMPLE_RESOURCE_MODEL_ATTACHMENTS = ImmutableList.of(
-            AttachmentContent.builder().name("name1").size(1).hashType("hashType1").hash("hash1").url("url1").build(),
-            AttachmentContent.builder().name("name2").size(2).hashType("hashType2").hash("hash2").url("url2").build()
-    );
+
     private static final List<software.amazon.awssdk.services.ssm.model.AttachmentContent> SAMPLE_GET_RESPONSE_ATTACHMENTS = ImmutableList.of(
             software.amazon.awssdk.services.ssm.model.AttachmentContent.builder()
                     .name("name1").size(1L).hash("hash1").hashType("hashType1").url("url1").build(),
@@ -55,26 +52,6 @@ public class DocumentResponseModelTranslatorTest {
 
         final ResourceInformation resourceInformation =
                 unitUnderTest.generateResourceInformation(createGetDocumentResponseWithAllAttributes());
-
-        Assertions.assertEquals(expectedResourceInformation, resourceInformation);
-    }
-
-    @Test
-    public void testGenerateCreateDocumentRequest_DocumentAttachmentsIsNull_verifyResult() {
-        final ResourceModel expectedModel = createResourceModelWithAllAttributes();
-        expectedModel.setAttachmentsContent(null);
-
-        final ResourceInformation expectedResourceInformation = ResourceInformation.builder()
-                .resourceModel(expectedModel)
-                .status(RESOURCE_MODEL_ACTIVE_STATE)
-                .statusInformation(SAMPLE_STATUS_INFO)
-                .build();
-
-        final GetDocumentResponse getDocumentResponse = createGetDocumentResponseWithAllAttributes().toBuilder()
-                .attachmentsContent((Collection<software.amazon.awssdk.services.ssm.model.AttachmentContent>) null).build();
-
-        final ResourceInformation resourceInformation =
-                unitUnderTest.generateResourceInformation(getDocumentResponse);
 
         Assertions.assertEquals(expectedResourceInformation, resourceInformation);
     }
@@ -187,7 +164,6 @@ public class DocumentResponseModelTranslatorTest {
                 .versionName(SAMPLE_VERSION_NAME)
                 .documentFormat(SAMPLE_DOCUMENT_FORMAT)
                 .documentType(SAMPLE_DOCUMENT_TYPE)
-                .attachmentsContent(SAMPLE_RESOURCE_MODEL_ATTACHMENTS)
                 .requires(SAMPLE_RESOURCE_MODEL_REQUIRES)
                 .build();
     }


### PR DESCRIPTION
remove AttachmentsContent attribute since array is not a supported ReadOnly property type

*Issue #, if available:*

*Description of changes:*
ReadOnly properties support only simple types like String but not array as of today. Removed that property. Also removed a "oneOf" property that's not being used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
