### PR TITLE
Return document tags in CreateHandler and ReadHandler response

### DIFF
--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
@@ -1,12 +1,12 @@
 package com.amazonaws.ssm.document;
 
 import lombok.NonNull;
-import org.apache.commons.collections.CollectionUtils;
 import software.amazon.awssdk.services.ssm.model.DocumentStatus;
 import software.amazon.awssdk.services.ssm.model.GetDocumentResponse;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 class DocumentResponseModelTranslator {
@@ -21,7 +21,8 @@ class DocumentResponseModelTranslator {
         return INSTANCE;
     }
 
-    ResourceInformation generateResourceInformation(@NonNull final GetDocumentResponse response) {
+    ResourceInformation generateResourceInformation(@NonNull final GetDocumentResponse response,
+                                                    @NonNull final Map<String, String> documentTagMap) {
         final ResourceModel model = ResourceModel.builder()
                 .name(response.name())
                 .versionName(response.versionName())
@@ -29,6 +30,7 @@ class DocumentResponseModelTranslator {
                 .documentType(response.documentTypeAsString())
                 .documentVersion(response.documentVersion())
                 .content(response.content())
+                .tags(translateToResourceModelTags(documentTagMap))
                 .requires(translateRequires(response))
                 .build();
 
@@ -56,6 +58,15 @@ class DocumentResponseModelTranslator {
             default:
                 throw new AssertionError(String.format("unknown Document Status: %s", status));
         }
+    }
+
+    private List<Tag> translateToResourceModelTags(final Map<String, String> tagMap) {
+        return tagMap.entrySet().stream()
+            .map(tagEntry -> Tag.builder()
+                .key(tagEntry.getKey())
+                .value(tagEntry.getValue())
+                .build())
+            .collect(Collectors.toList());
     }
 
     private List<DocumentRequires> translateRequires(final GetDocumentResponse response) {

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagClient.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagClient.java
@@ -2,6 +2,7 @@ package com.amazonaws.ssm.document.tags;
 
 import java.util.List;
 import com.google.common.collect.ImmutableList;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.AddTagsToResourceRequest;
@@ -12,6 +13,7 @@ import software.amazon.awssdk.services.ssm.model.ResourceTypeForTagging;
 import software.amazon.awssdk.services.ssm.model.Tag;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 
+@NoArgsConstructor
 public class TagClient {
 
     private static TagClient INSTANCE;

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagReader.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagReader.java
@@ -1,0 +1,46 @@
+package com.amazonaws.ssm.document.tags;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.Tag;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+
+@RequiredArgsConstructor
+public class TagReader {
+    private static TagReader INSTANCE;
+
+    @NonNull
+    private final TagClient tagClient;
+
+    public static TagReader getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new TagReader(TagClient.getInstance());
+        }
+
+        return INSTANCE;
+    }
+
+    public Map<String, String> getDocumentTags(@NonNull final String documentName,
+                                                     @NonNull final SsmClient ssmClient,
+                                                     @NonNull final AmazonWebServicesClientProxy proxy) {
+        final List<Tag> documentTags = tagClient.listTags(documentName, ssmClient, proxy);
+
+        return translateTags(documentTags);
+    }
+
+    private Map<String, String> translateTags(final List<Tag> tags) {
+        final ImmutableMap.Builder<String, String> tagBuilder = ImmutableMap.builder();
+
+        tags.forEach(tag -> tagBuilder.put(tag.key(), tag.value()));
+
+        return tagBuilder.build();
+    }
+}

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentResponseModelTranslatorTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentResponseModelTranslatorTest.java
@@ -1,6 +1,7 @@
 package com.amazonaws.ssm.document;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.ssm.model.DocumentStatus;
@@ -8,6 +9,7 @@ import software.amazon.awssdk.services.ssm.model.GetDocumentResponse;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 public class DocumentResponseModelTranslatorTest {
     private static final String SAMPLE_DOCUMENT_NAME = "sampleDocument";
@@ -20,6 +22,10 @@ public class DocumentResponseModelTranslatorTest {
     private static final List<Tag> SAMPLE_RESOURCE_MODEL_TAGS = ImmutableList.of(
             Tag.builder().key("tagKey1").value("tagValue1").build(),
             Tag.builder().key("tagKey2").value("tagValue2").build()
+    );
+    private static final Map<String, String> SAMPLE_TAG_MAP = ImmutableMap.of(
+        "tagKey1", "tagValue1",
+        "tagKey2", "tagValue2"
     );
 
     private static final List<software.amazon.awssdk.services.ssm.model.AttachmentContent> SAMPLE_GET_RESPONSE_ATTACHMENTS = ImmutableList.of(
@@ -43,7 +49,7 @@ public class DocumentResponseModelTranslatorTest {
     private final DocumentResponseModelTranslator unitUnderTest = new DocumentResponseModelTranslator();
 
     @Test
-    public void testGenerateCreateDocumentRequest_DocumentNameIsProvided_verifyResult() {
+    public void testGenerateResourceInformation_DocumentNameIsProvided_verifyResult() {
         final ResourceInformation expectedResourceInformation = ResourceInformation.builder()
                 .resourceModel(createResourceModelWithAllAttributes())
                 .status(RESOURCE_MODEL_ACTIVE_STATE)
@@ -51,13 +57,13 @@ public class DocumentResponseModelTranslatorTest {
                 .build();
 
         final ResourceInformation resourceInformation =
-                unitUnderTest.generateResourceInformation(createGetDocumentResponseWithAllAttributes());
+                unitUnderTest.generateResourceInformation(createGetDocumentResponseWithAllAttributes(), SAMPLE_TAG_MAP);
 
         Assertions.assertEquals(expectedResourceInformation, resourceInformation);
     }
 
     @Test
-    public void testGenerateCreateDocumentRequest_DocumentRequiresIsNull_verifyResult() {
+    public void testGenerateResourceInformation_DocumentRequiresIsNull_verifyResult() {
         final ResourceModel expectedModel = createResourceModelWithAllAttributes();
         expectedModel.setRequires(null);
         final ResourceInformation expectedResourceInformation = ResourceInformation.builder()
@@ -70,13 +76,13 @@ public class DocumentResponseModelTranslatorTest {
                 .requires((Collection<software.amazon.awssdk.services.ssm.model.DocumentRequires>)null).build();
 
         final ResourceInformation resourceInformation =
-                unitUnderTest.generateResourceInformation(getDocumentResponse);
+                unitUnderTest.generateResourceInformation(getDocumentResponse, SAMPLE_TAG_MAP);
 
         Assertions.assertEquals(expectedResourceInformation, resourceInformation);
     }
 
     @Test
-    public void testGenerateCreateDocumentRequest_DocumentStatusIsActive_verifyResult() {
+    public void testGenerateResourceInformation_DocumentStatusIsActive_verifyResult() {
         final ResourceInformation expectedResourceInformation = ResourceInformation.builder()
                 .resourceModel(createResourceModelWithAllAttributes())
                 .status(RESOURCE_MODEL_ACTIVE_STATE)
@@ -85,11 +91,12 @@ public class DocumentResponseModelTranslatorTest {
 
         final GetDocumentResponse getDocumentResponse = createGetDocumentResponseWithAllAttributes();
 
-        Assertions.assertEquals(expectedResourceInformation, unitUnderTest.generateResourceInformation(getDocumentResponse));
+        Assertions.assertEquals(expectedResourceInformation,
+            unitUnderTest.generateResourceInformation(getDocumentResponse, SAMPLE_TAG_MAP));
     }
 
     @Test
-    public void testGenerateCreateDocumentRequest_DocumentStatusIsCreating_verifyResult() {
+    public void testGenerateResourceInformation_DocumentStatusIsCreating_verifyResult() {
         final DocumentStatus documentStatus = DocumentStatus.CREATING;
         final ResourceStatus creating = ResourceStatus.CREATING;
 
@@ -102,11 +109,12 @@ public class DocumentResponseModelTranslatorTest {
         final GetDocumentResponse getDocumentResponse = createGetDocumentResponseWithAllAttributes().toBuilder()
                 .status(documentStatus).build();
 
-        Assertions.assertEquals(expectedResourceInformation, unitUnderTest.generateResourceInformation(getDocumentResponse));
+        Assertions.assertEquals(expectedResourceInformation,
+            unitUnderTest.generateResourceInformation(getDocumentResponse, SAMPLE_TAG_MAP));
     }
 
     @Test
-    public void testGenerateCreateDocumentRequest_DocumentStatusIsUpdating_verifyResult() {
+    public void testGenerateResourceInformation_DocumentStatusIsUpdating_verifyResult() {
         final DocumentStatus documentStatus = DocumentStatus.UPDATING;
         final ResourceStatus expectedResourceStatus = ResourceStatus.UPDATING;
 
@@ -119,11 +127,12 @@ public class DocumentResponseModelTranslatorTest {
         final GetDocumentResponse getDocumentResponse = createGetDocumentResponseWithAllAttributes().toBuilder()
                 .status(documentStatus).build();
 
-        Assertions.assertEquals(expectedResourceInformation, unitUnderTest.generateResourceInformation(getDocumentResponse));
+        Assertions.assertEquals(expectedResourceInformation,
+            unitUnderTest.generateResourceInformation(getDocumentResponse, SAMPLE_TAG_MAP));
     }
 
     @Test
-    public void testGenerateCreateDocumentRequest_DocumentStatusIsDeleting_verifyResult() {
+    public void testGenerateResourceInformation_DocumentStatusIsDeleting_verifyResult() {
         final DocumentStatus documentStatus = DocumentStatus.DELETING;
         final ResourceStatus expectedResourceStatus = ResourceStatus.DELETING;
 
@@ -136,11 +145,12 @@ public class DocumentResponseModelTranslatorTest {
         final GetDocumentResponse getDocumentResponse = createGetDocumentResponseWithAllAttributes().toBuilder()
                 .status(documentStatus).build();
 
-        Assertions.assertEquals(expectedResourceInformation, unitUnderTest.generateResourceInformation(getDocumentResponse));
+        Assertions.assertEquals(expectedResourceInformation,
+            unitUnderTest.generateResourceInformation(getDocumentResponse, SAMPLE_TAG_MAP));
     }
 
     @Test
-    public void testGenerateCreateDocumentRequest_DocumentStatusIsFailed_verifyResult() {
+    public void testGenerateResourceInformation_DocumentStatusIsFailed_verifyResult() {
         final DocumentStatus documentStatus = DocumentStatus.FAILED;
         final ResourceStatus expectedResourceStatus = ResourceStatus.FAILED;
 
@@ -153,7 +163,8 @@ public class DocumentResponseModelTranslatorTest {
         final GetDocumentResponse getDocumentResponse = createGetDocumentResponseWithAllAttributes().toBuilder()
                 .status(documentStatus).build();
 
-        Assertions.assertEquals(expectedResourceInformation, unitUnderTest.generateResourceInformation(getDocumentResponse));
+        Assertions.assertEquals(expectedResourceInformation,
+            unitUnderTest.generateResourceInformation(getDocumentResponse, SAMPLE_TAG_MAP));
     }
 
     private ResourceModel createResourceModelWithAllAttributes() {
@@ -164,6 +175,7 @@ public class DocumentResponseModelTranslatorTest {
                 .versionName(SAMPLE_VERSION_NAME)
                 .documentFormat(SAMPLE_DOCUMENT_FORMAT)
                 .documentType(SAMPLE_DOCUMENT_TYPE)
+                .tags(SAMPLE_RESOURCE_MODEL_TAGS)
                 .requires(SAMPLE_RESOURCE_MODEL_REQUIRES)
                 .build();
     }

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/tags/TagReaderTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/tags/TagReaderTest.java
@@ -1,0 +1,55 @@
+package com.amazonaws.ssm.document.tags;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.Tag;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+
+@ExtendWith(MockitoExtension.class)
+public class TagReaderTest {
+
+    private static final String SAMPLE_DOCUMENT_NAME = "sampleDocument";
+
+    private static final List<Tag> SAMPLE_EXISTING_TAGS = ImmutableList.of(
+        Tag.builder().key("tagKey1").value("tagValue1").build(),
+        Tag.builder().key("tagKey2").value("tagValue2").build()
+    );
+
+    private static final Map<String, String> SAMPLE_TAG_MAP = ImmutableMap.of(
+        "tagKey1", "tagValue1",
+        "tagKey2", "tagValue2"
+    );
+
+    @Mock
+    private SsmClient ssmClient;
+
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    private TagClient tagClient;
+
+    private TagReader unitUnderTest;
+
+    @BeforeEach
+    private void setup() {
+        unitUnderTest = new TagReader(tagClient);
+    }
+
+    @Test
+    public void testGetDocumentTags_verifyResponse() {
+        Mockito.when(tagClient.listTags(SAMPLE_DOCUMENT_NAME, ssmClient, proxy)).thenReturn(SAMPLE_EXISTING_TAGS);
+
+        Assertions.assertEquals(SAMPLE_TAG_MAP, unitUnderTest.getDocumentTags(SAMPLE_DOCUMENT_NAME, ssmClient, proxy));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Return document tags in CreateHandler and ReadHandler response as per the Resource Provider contract.
Also fixed some unit test names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
