### PR TITLE
remove documentVersion attribute

### DIFF
--- a/aws-ssm-association/pom.xml
+++ b/aws-ssm-association/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>[2.0.0, 3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-ssm-document/aws-ssm-document.json
+++ b/aws-ssm-document/aws-ssm-document.json
@@ -184,11 +184,6 @@
             "permissions": [
                 "ssm:DeleteDocument"
             ]
-        },
-        "list": {
-            "permissions": [
-                "ssm:ListDocuments"
-            ]
         }
     }
 }

--- a/aws-ssm-document/aws-ssm-document.json
+++ b/aws-ssm-document/aws-ssm-document.json
@@ -148,10 +148,6 @@
                 "$ref": "#/definitions/DocumentRequires"
             },
             "minItems": 1
-        },
-        "DocumentVersion": {
-            "description": "The latest version number of document",
-            "type": "string"
         }
     },
     "additionalProperties": false,
@@ -159,9 +155,6 @@
     "createOnlyProperties": [
         "/properties/Name",
         "/properties/DocumentType"
-    ],
-    "readOnlyProperties": [
-        "/properties/DocumentVersion"
     ],
     "primaryIdentifier": [
         "/properties/Name"

--- a/aws-ssm-document/inputs/inputs_1_create.json
+++ b/aws-ssm-document/inputs/inputs_1_create.json
@@ -1,0 +1,12 @@
+{
+    "Name": "calendarTest1",
+    "Content": "BEGIN:VCALENDAR\r\nPRODID:-//AWS//Change Calendar 1.0//EN\r\nVERSION:2.0\r\nX-CALENDAR-TYPE:DEFAULT_OPEN\r\nX-WR-CALDESC:test\r\nBEGIN:VTODO\r\nDTSTAMP:20200320T004207Z\r\nUID:3b5af39a-d0b3-4049-a839-d7bb8af01f92\r\nSUMMARY:Add events to this calendar.\r\nEND:VTODO\r\nEND:VCALENDAR\r\n",
+    "DocumentType": "ChangeCalendar",
+    "DocumentFormat": "TEXT",
+    "Tags": [
+        {
+            "Key": "CanaryTagKey",
+            "Value": "CanaryTagValueA"
+        }
+    ]
+}

--- a/aws-ssm-document/inputs/inputs_1_invalid.json
+++ b/aws-ssm-document/inputs/inputs_1_invalid.json
@@ -1,0 +1,12 @@
+{
+    "Name": "calendarTest2",
+    "Content": "BEGIN:VCALENDAR\r\nPRODID:-//AWS//Change Calendar 1.0//EN\r\nVERSION:2.0\r\nX-CALENDAR-TYPE:DEFAULT_OPEN\r\nX-WR-CALDESC:test\r\nBEGIN:VTODO\r\nDTSTAMP:20200320T004207Z\r\nUID:3b5af39a-d0b3-4049-a839-d7bb8af01f92\r\nSUMMARY:Add events to this calendar2.\r\nEND:VTODO\r\nEND:VCALENDAR\r\n",
+    "DocumentType": "Command",
+    "DocumentFormat": "TEXT",
+    "Tags": [
+        {
+            "Key": "CanaryTagKey",
+            "Value": "CanaryTagValueA"
+        }
+    ]
+}

--- a/aws-ssm-document/inputs/inputs_1_update.json
+++ b/aws-ssm-document/inputs/inputs_1_update.json
@@ -1,0 +1,13 @@
+{
+    "Name": "calendarTest1",
+    "Content": "BEGIN:VCALENDAR\r\nPRODID:-//AWS//Change Calendar 1.0//EN\r\nVERSION:2.0\r\nX-CALENDAR-TYPE:DEFAULT_OPEN\r\nX-WR-CALDESC:test\r\nBEGIN:VTODO\r\nDTSTAMP:20200320T004207Z\r\nUID:3b5af39a-d0b3-4049-a839-d7bb8af01f92\r\nSUMMARY:Add events to this calendar2.\r\nEND:VTODO\r\nEND:VCALENDAR\r\n",
+    "DocumentType": "ChangeCalendar",
+    "DocumentFormat": "TEXT",
+    "DocumentVersion": "5",
+    "Tags": [
+        {
+            "Key": "CanaryTagKey",
+            "Value": "CanaryTagValueA"
+        }
+    ]
+}

--- a/aws-ssm-document/pom.xml
+++ b/aws-ssm-document/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>[2.0.0, 3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-ssm-document/resource-role.yaml
+++ b/aws-ssm-document/resource-role.yaml
@@ -28,7 +28,6 @@ Resources:
                 - "ssm:CreateDocument"
                 - "ssm:DeleteDocument"
                 - "ssm:GetDocument"
-                - "ssm:ListDocuments"
                 - "ssm:ListTagsForResource"
                 - "ssm:RemoveTagsFromResource"
                 - "ssm:UpdateDocument"

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/CreateHandler.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/CreateHandler.java
@@ -105,13 +105,18 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
 
         final ResourceInformation resourceInformation = progressResponse.getResourceInformation();
 
+        final OperationStatus operationStatus = getOperationStatus(resourceInformation.getStatus());
         return ProgressEvent.<ResourceModel, CallbackContext>builder()
                 .resourceModel(resourceInformation.getResourceModel())
-                .status(getOperationStatus(resourceInformation.getStatus()))
+                .status(operationStatus)
                 .message(resourceInformation.getStatusInformation())
                 .callbackContext(progressResponse.getCallbackContext())
-                .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
+                .callbackDelaySeconds(setCallbackDelay(operationStatus))
                 .build();
+    }
+
+    private int setCallbackDelay(final OperationStatus operationStatus) {
+        return operationStatus == OperationStatus.SUCCESS ? 0 : CALLBACK_DELAY_SECONDS;
     }
 
     private OperationStatus getOperationStatus(@NonNull final ResourceStatus status) {

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DeleteHandler.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DeleteHandler.java
@@ -103,9 +103,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
 
     private ProgressEvent<ResourceModel, CallbackContext> getDeleteSuccessEvent(final ResourceModel model) {
         return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                .resourceModel(model)
                 .status(OperationStatus.SUCCESS)
-                .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
                 .build();
     }
 

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentModelTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentModelTranslator.java
@@ -84,7 +84,7 @@ class DocumentModelTranslator {
     GetDocumentRequest generateGetDocumentRequest(@NonNull final ResourceModel model) {
         return GetDocumentRequest.builder()
                 .name(model.getName())
-                .documentVersion(model.getDocumentVersion())
+                .documentVersion(LATEST_DOCUMENT_VERSION)
                 .documentFormat(model.getDocumentFormat())
                 .build();
     }

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
@@ -28,7 +28,6 @@ class DocumentResponseModelTranslator {
                 .versionName(response.versionName())
                 .documentFormat(response.documentFormatAsString())
                 .documentType(response.documentTypeAsString())
-                .documentVersion(response.documentVersion())
                 .content(response.content())
                 .tags(translateToResourceModelTags(documentTagMap))
                 .requires(translateRequires(response))

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/UpdateHandler.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/UpdateHandler.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.ssm.model.UpdateDocumentRequest;
 import software.amazon.awssdk.services.ssm.model.UpdateDocumentResponse;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -116,12 +117,13 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
 
        final ResourceInformation resourceInformation = progressResponse.getResourceInformation();
 
+       final OperationStatus operationStatus = getOperationStatus(resourceInformation.getStatus());
         return ProgressEvent.<ResourceModel, CallbackContext>builder()
                 .resourceModel(resourceInformation.getResourceModel())
-                .status(getOperationStatus(resourceInformation.getStatus()))
+                .status(operationStatus)
                 .message(resourceInformation.getStatusInformation())
                 .callbackContext(progressResponse.getCallbackContext())
-                .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
+                .callbackDelaySeconds(setCallbackDelay(operationStatus))
                 .build();
     }
 
@@ -151,5 +153,9 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
             default:
                 return OperationStatus.FAILED;
         }
+    }
+
+    private int setCallbackDelay(final OperationStatus operationStatus) {
+        return operationStatus == OperationStatus.SUCCESS ? 0 : CALLBACK_DELAY_SECONDS;
     }
 }

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/CreateHandlerTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/CreateHandlerTest.java
@@ -198,7 +198,6 @@ public class CreateHandlerTest {
                 .status(OperationStatus.SUCCESS)
                 .message(SAMPLE_STATUS_INFO)
                 .callbackContext(expectedCallbackContext)
-                .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
                 .build();
 
         when(progressUpdater.getEventProgress(SAMPLE_RESOURCE_MODEL, inProgressCallbackContext, ssmClient, proxy, logger))

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DeleteHandlerTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DeleteHandlerTest.java
@@ -212,9 +212,7 @@ public class DeleteHandlerTest {
                 .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> expectedResponse = ProgressEvent.<ResourceModel, CallbackContext>builder()
-                .resourceModel(SAMPLE_RESOURCE_MODEL)
                 .status(OperationStatus.SUCCESS)
-                .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
                 .build();
 
         when(progressUpdater.getEventProgress(SAMPLE_RESOURCE_MODEL, inProgressCallbackContext, ssmClient, proxy, logger))

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentModelTranslatorTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentModelTranslatorTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.ssm.model.CreateDocumentRequest;
 import software.amazon.awssdk.services.ssm.model.DeleteDocumentRequest;
+import software.amazon.awssdk.services.ssm.model.GetDocumentRequest;
+import software.amazon.awssdk.services.ssm.model.GetDocumentResponse;
 import software.amazon.awssdk.services.ssm.model.UpdateDocumentRequest;
 
 import java.util.List;
@@ -346,6 +348,22 @@ public class DocumentModelTranslatorTest {
                 .build();
 
         final DeleteDocumentRequest request = unitUnderTest.generateDeleteDocumentRequest(model);
+
+        Assertions.assertEquals(expectedRequest, request);
+    }
+
+    //GetDocumentRequest tests
+    @Test
+    public void testGenerateGetDocumentRequest_verifyResult() {
+        final ResourceModel model = createResourceModel();
+
+        final GetDocumentRequest expectedRequest = GetDocumentRequest.builder()
+            .name(SAMPLE_DOCUMENT_NAME)
+            .documentVersion(LATEST_DOCUMENT_VERSION)
+            .documentFormat(SAMPLE_DOCUMENT_FORMAT)
+            .build();
+
+        final GetDocumentRequest request = unitUnderTest.generateGetDocumentRequest(model);
 
         Assertions.assertEquals(expectedRequest, request);
     }

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentResponseModelTranslatorTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentResponseModelTranslatorTest.java
@@ -171,7 +171,6 @@ public class DocumentResponseModelTranslatorTest {
         return ResourceModel.builder()
                 .name(SAMPLE_DOCUMENT_NAME)
                 .content(SAMPLE_DOCUMENT_CONTENT)
-                .documentVersion(SAMPLE_DOCUMENT_VERSION)
                 .versionName(SAMPLE_VERSION_NAME)
                 .documentFormat(SAMPLE_DOCUMENT_FORMAT)
                 .documentType(SAMPLE_DOCUMENT_TYPE)

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/UpdateHandlerTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/UpdateHandlerTest.java
@@ -43,6 +43,10 @@ public class UpdateHandlerTest {
             "schemaVersion", "1.2",
             "description", "Join instances to an AWS Directory Service domain."
     );
+    private static final Map<String, Object> SAMPLE_PREVIOUS_DOCUMENT_CONTENT = ImmutableMap.of(
+        "schemaVersion", "1.1",
+        "description", "Join instances to an AWS Directory Service domain."
+    );
     private static final Map<String, String> SAMPLE_SYSTEM_TAGS = ImmutableMap.of("aws:cloudformation:stack-name", "testStack");
     private static final Map<String, String> SAMPLE_DESIRED_RESOURCE_TAGS = ImmutableMap.of("tagKey1", "tagValue1");
     private static final String SAMPLE_REQUEST_TOKEN = "sampleRequestToken";
@@ -55,6 +59,10 @@ public class UpdateHandlerTest {
             .name(SAMPLE_DOCUMENT_NAME)
             .content(SAMPLE_DOCUMENT_CONTENT)
             .build();
+    private static final ResourceModel SAMPLE_PREVIOUS_RESOURCE_MODEL = ResourceModel.builder()
+        .name(SAMPLE_DOCUMENT_NAME)
+        .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+        .build();
     private static final ResourceHandlerRequest<ResourceModel> SAMPLE_RESOURCE_HANDLER_REQUEST = ResourceHandlerRequest.<ResourceModel>builder()
             .systemTags(SAMPLE_SYSTEM_TAGS)
             .desiredResourceTags(SAMPLE_DESIRED_RESOURCE_TAGS)
@@ -252,7 +260,6 @@ public class UpdateHandlerTest {
                 .status(OperationStatus.SUCCESS)
                 .message(SAMPLE_STATUS_INFO)
                 .callbackContext(expectedCallbackContext)
-                .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
                 .build();
 
         when(progressUpdater.getEventProgress(SAMPLE_RESOURCE_MODEL, inProgressCallbackContext, ssmClient, proxy, logger))

--- a/aws-ssm-maintenancewindow/pom.xml
+++ b/aws-ssm-maintenancewindow/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>[2.0.0, 3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-ssm-maintenancewindowtarget/pom.xml
+++ b/aws-ssm-maintenancewindowtarget/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>[2.0.0, 3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-ssm-maintenancewindowtask/pom.xml
+++ b/aws-ssm-maintenancewindowtask/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>[2.0.0, 3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/aws-ssm-parameter/pom.xml
+++ b/aws-ssm-parameter/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>[2.0.0, 3.0.0)</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cloudformation when sending a Request in READ handler, includes only the primaryIdentifier of the resource, which is document name. But currently, if GetDocument is called without DocumentFormat attribute, it defaults to Json. This is a problem for document types that are not Json, like ChangeCalendar. This results in failure when user tries to use Fn::GetAtt on ReadOnly attributes like DocumentVersion.

So, removing DocumentVersion as a ReadOnly attribute. It can be introduced back when DocumentFormat is not required for GetDocument API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
