### PR TITLE
remove chagneCalendar document type

### DIFF
--- a/aws-ssm-document/aws-ssm-document.json
+++ b/aws-ssm-document/aws-ssm-document.json
@@ -110,7 +110,6 @@
                 "ApplicationConfiguration",
                 "ApplicationConfigurationSchema",
                 "Automation",
-                "ChangeCalendar",
                 "Command",
                 "DeploymentStrategy",
                 "Package",
@@ -119,12 +118,11 @@
             ]
         },
         "DocumentFormat": {
-            "description": "Specify the document format for the request. The document format can be either JSON, YAML or TEXT. JSON is the default format.",
+            "description": "Specify the document format for the request. The document format can be either JSON or YAML. JSON is the default format.",
             "type": "string",
             "enum": [
                 "YAML",
-                "JSON",
-                "TEXT"
+                "JSON"
             ],
             "default": "JSON"
         },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cloudformation when sending a Request in READ handler, includes only the primaryIdentifier of the resource, which is document name. But currently, if GetDocument is called without DocumentFormat attribute, it defaults to Json. This is a problem for document types that are not Json, like ChangeCalendar. This results in failure when user tries to use Fn::GetAtt or driftDetection. Removing ChangeCalendar support temporarily until a solution is figured out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
