### PR TITLE
Modify document resource contract test inputs

### DIFF
--- a/aws-ssm-document/inputs/inputs_1_create.json
+++ b/aws-ssm-document/inputs/inputs_1_create.json
@@ -22,8 +22,8 @@
             }
         ]
     },
-    "DocumentType": "ChangeCalendar",
-    "DocumentFormat": "TEXT",
+    "DocumentType": "Command",
+    "DocumentFormat": "JSON",
     "Tags": [
         {
             "Key": "CanaryTagKey",

--- a/aws-ssm-document/inputs/inputs_1_create.json
+++ b/aws-ssm-document/inputs/inputs_1_create.json
@@ -1,6 +1,27 @@
 {
     "Name": "calendarTest1",
-    "Content": "BEGIN:VCALENDAR\r\nPRODID:-//AWS//Change Calendar 1.0//EN\r\nVERSION:2.0\r\nX-CALENDAR-TYPE:DEFAULT_OPEN\r\nX-WR-CALDESC:test\r\nBEGIN:VTODO\r\nDTSTAMP:20200320T004207Z\r\nUID:3b5af39a-d0b3-4049-a839-d7bb8af01f92\r\nSUMMARY:Add events to this calendar.\r\nEND:VTODO\r\nEND:VCALENDAR\r\n",
+    "Content": {
+        "schemaVersion": "2.2",
+        "description": "Command Document Example Create JSON Template",
+        "parameters": {
+            "Message": {
+                "type": "String",
+                "description": "Example",
+                "default": "Hello World"
+            }
+        },
+        "mainSteps": [
+            {
+                "action": "aws:runPowerShellScript",
+                "name": "example",
+                "inputs": {
+                    "runCommand": [
+                        "Write-Output {{Message}}"
+                    ]
+                }
+            }
+        ]
+    },
     "DocumentType": "ChangeCalendar",
     "DocumentFormat": "TEXT",
     "Tags": [

--- a/aws-ssm-document/inputs/inputs_1_invalid.json
+++ b/aws-ssm-document/inputs/inputs_1_invalid.json
@@ -1,8 +1,29 @@
 {
     "Name": "calendarTest2",
-    "Content": "BEGIN:VCALENDAR\r\nPRODID:-//AWS//Change Calendar 1.0//EN\r\nVERSION:2.0\r\nX-CALENDAR-TYPE:DEFAULT_OPEN\r\nX-WR-CALDESC:test\r\nBEGIN:VTODO\r\nDTSTAMP:20200320T004207Z\r\nUID:3b5af39a-d0b3-4049-a839-d7bb8af01f92\r\nSUMMARY:Add events to this calendar2.\r\nEND:VTODO\r\nEND:VCALENDAR\r\n",
+    "Content": {
+        "schemaVersion": "2.2",
+        "description": "Command Document Example Update JSON Template",
+        "parameters": {
+            "Message": {
+                "type": "String",
+                "description": "Example",
+                "default": "Hello World"
+            }
+        },
+        "mainSteps": [
+            {
+                "action": "aws:runPowerShellScript",
+                "name": "example",
+                "inputs": {
+                    "runCommand": [
+                        "Write-Output {{Message}}"
+                    ]
+                }
+            }
+        ]
+    },
     "DocumentType": "Command",
-    "DocumentFormat": "TEXT",
+    "DocumentFormat": "JSON",
     "Tags": [
         {
             "Key": "CanaryTagKey",

--- a/aws-ssm-document/inputs/inputs_1_update.json
+++ b/aws-ssm-document/inputs/inputs_1_update.json
@@ -1,9 +1,29 @@
 {
     "Name": "calendarTest1",
-    "Content": "BEGIN:VCALENDAR\r\nPRODID:-//AWS//Change Calendar 1.0//EN\r\nVERSION:2.0\r\nX-CALENDAR-TYPE:DEFAULT_OPEN\r\nX-WR-CALDESC:test\r\nBEGIN:VTODO\r\nDTSTAMP:20200320T004207Z\r\nUID:3b5af39a-d0b3-4049-a839-d7bb8af01f92\r\nSUMMARY:Add events to this calendar2.\r\nEND:VTODO\r\nEND:VCALENDAR\r\n",
-    "DocumentType": "ChangeCalendar",
-    "DocumentFormat": "TEXT",
-    "DocumentVersion": "5",
+    "Content": {
+        "schemaVersion": "2.2",
+        "description": "Command Document Example Update JSON Template",
+        "parameters": {
+            "Message": {
+                "type": "String",
+                "description": "Example",
+                "default": "Hello World"
+            }
+        },
+        "mainSteps": [
+            {
+                "action": "aws:runPowerShellScript",
+                "name": "example",
+                "inputs": {
+                    "runCommand": [
+                        "Write-Output {{Message}}"
+                    ]
+                }
+            }
+        ]
+    },
+    "DocumentType": "Command",
+    "DocumentFormat": "JSON",
     "Tags": [
         {
             "Key": "CanaryTagKey",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use Command document type for contract test inputs instead of ChangeCalendar. ChangeCalendar is not supported currently.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
