### PR TITLE
Adding progress chaining to UpdateHandler for AWS::SSM::Association

### DIFF
--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/CallbackContext.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/CallbackContext.java
@@ -1,21 +1,25 @@
 package com.amazonaws.ssm.association;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Context object passed from CloudFormation calls to handlers.
  */
-@Value
-@Builder
+@Builder(toBuilder = true)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class CallbackContext {
     /**
      * Number of seconds remaining for completion of resource stabilization.
      */
-    private final int remainingTimeoutSeconds;
+    private int remainingTimeoutSeconds;
 
     /**
      * Primary identifier of the resource, needed to find the resource in subsequent calls.
      */
-    private final String associationId;
+    private String associationId;
 }

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/InitialUpdateHandler.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/InitialUpdateHandler.java
@@ -16,7 +16,7 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 /**
- * Handles update requests on a given resource.
+ * Handles initial update requests on a given resource.
  */
 public class InitialUpdateHandler extends BaseHandler<CallbackContext> {
 
@@ -27,7 +27,7 @@ public class InitialUpdateHandler extends BaseHandler<CallbackContext> {
     private final InProgressEventCreator inProgressEventCreator;
 
     /**
-     * Constructor to use by dependencies. Processes Update requests.
+     * Constructor to use by dependencies. Processes initial UpdateHandler requests.
      */
     InitialUpdateHandler(final SsmClient ssmClient) {
         this.ssmClient = ssmClient;

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/InitialUpdateHandler.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/InitialUpdateHandler.java
@@ -1,0 +1,113 @@
+package com.amazonaws.ssm.association;
+
+import com.amazonaws.ssm.association.translator.AssociationDescriptionTranslator;
+import com.amazonaws.ssm.association.translator.ExceptionTranslator;
+import com.amazonaws.ssm.association.translator.request.UpdateAssociationTranslator;
+import com.amazonaws.util.StringUtils;
+
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.AssociationDescription;
+import software.amazon.awssdk.services.ssm.model.UpdateAssociationRequest;
+import software.amazon.cloudformation.exceptions.BaseHandlerException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+/**
+ * Handles update requests on a given resource.
+ */
+public class InitialUpdateHandler extends BaseHandler<CallbackContext> {
+
+    private final SsmClient ssmClient;
+    private final UpdateAssociationTranslator updateAssociationTranslator;
+    private final AssociationDescriptionTranslator associationDescriptionTranslator;
+    private final ExceptionTranslator exceptionTranslator;
+    private final InProgressEventCreator inProgressEventCreator;
+
+    /**
+     * Constructor to use by dependencies. Processes Update requests.
+     */
+    InitialUpdateHandler(final SsmClient ssmClient) {
+        this.ssmClient = ssmClient;
+        this.updateAssociationTranslator = new UpdateAssociationTranslator();
+        this.associationDescriptionTranslator = new AssociationDescriptionTranslator();
+        this.exceptionTranslator = new ExceptionTranslator();
+        this.inProgressEventCreator = new InProgressEventCreator();
+    }
+
+    /**
+     * Used for unit tests.
+     *
+     * @param ssmClient                        SsmClient implementation to use for API calls.
+     * @param updateAssociationTranslator      Translates ResourceModel objects into UpdateAssociation requests.
+     * @param associationDescriptionTranslator Translates AssociationDescription into ResourceModel objects.
+     * @param exceptionTranslator              Translates service model exceptions.
+     * @param inProgressEventCreator           Creates InProgress ProgressEvent objects for progress chaining.
+     */
+    InitialUpdateHandler(
+        final SsmClient ssmClient,
+        final UpdateAssociationTranslator updateAssociationTranslator,
+        final AssociationDescriptionTranslator associationDescriptionTranslator,
+        final ExceptionTranslator exceptionTranslator,
+        final InProgressEventCreator inProgressEventCreator) {
+
+        this.ssmClient = ssmClient;
+        this.updateAssociationTranslator = updateAssociationTranslator;
+        this.associationDescriptionTranslator = associationDescriptionTranslator;
+        this.exceptionTranslator = exceptionTranslator;
+        this.inProgressEventCreator = inProgressEventCreator;
+    }
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+        final AmazonWebServicesClientProxy proxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final CallbackContext callbackContext,
+        final Logger logger) {
+
+        final ResourceModel requestModel = request.getDesiredResourceState();
+
+        final String associationId = requestModel.getAssociationId();
+
+        if (StringUtils.isNullOrEmpty(associationId)) {
+            return ProgressEvent.failed(request.getPreviousResourceState(),
+                callbackContext,
+                HandlerErrorCode.InvalidRequest,
+                "AssociationId must be present to update the existing association.");
+        }
+
+        final UpdateAssociationRequest updateAssociationRequest =
+            updateAssociationTranslator.resourceModelToRequest(requestModel);
+
+        final AssociationDescription resultAssociationDescription;
+
+        try {
+            resultAssociationDescription =
+                proxy.injectCredentialsAndInvokeV2(updateAssociationRequest, ssmClient::updateAssociation)
+                    .associationDescription();
+
+        } catch (Exception e) {
+            final BaseHandlerException cfnException = exceptionTranslator
+                .translateFromServiceException(e, updateAssociationRequest, requestModel);
+
+            logger.log(cfnException.getCause().getMessage());
+
+            throw cfnException;
+        }
+
+        final ResourceModel updatedModel =
+            associationDescriptionTranslator.associationDescriptionToResourceModel(resultAssociationDescription);
+
+        final Integer waitForSuccessTimeoutSeconds = requestModel.getWaitForSuccessTimeoutSeconds();
+
+        if (waitForSuccessTimeoutSeconds == null) {
+            // return success without waiting for association to complete
+            return ProgressEvent.defaultSuccessHandler(updatedModel);
+        } else {
+            // indicates an Update request that needs to wait for association to complete
+            return inProgressEventCreator.nextInProgressEvent(waitForSuccessTimeoutSeconds, updatedModel);
+        }
+    }
+}

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/UpdateHandler.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/UpdateHandler.java
@@ -1,20 +1,12 @@
 package com.amazonaws.ssm.association;
 
-import com.amazonaws.ssm.association.translator.AssociationDescriptionTranslator;
-import com.amazonaws.ssm.association.translator.ExceptionTranslator;
-import com.amazonaws.ssm.association.translator.request.UpdateAssociationTranslator;
 import com.amazonaws.ssm.association.util.ResourceHandlerRequestToStringConverter;
 import com.amazonaws.ssm.association.util.ResourceModelToStringConverter;
 import com.amazonaws.ssm.association.util.SsmClientBuilder;
-import com.amazonaws.util.StringUtils;
+
 import software.amazon.awssdk.services.ssm.SsmClient;
-import software.amazon.awssdk.services.ssm.model.AssociationDescription;
-import software.amazon.awssdk.services.ssm.model.UpdateAssociationRequest;
-import software.amazon.cloudformation.exceptions.BaseHandlerException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
@@ -25,36 +17,33 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
 
     private static final SsmClient SSM_CLIENT = SsmClientBuilder.getClient();
 
-    private final UpdateAssociationTranslator updateAssociationTranslator;
-    private final AssociationDescriptionTranslator associationDescriptionTranslator;
-    private final ExceptionTranslator exceptionTranslator;
+    private final BaseHandler<CallbackContext> initialUpdateHandler;
+    private final BaseHandler<CallbackContext> inProgressHandler;
     private final ResourceHandlerRequestToStringConverter requestToStringConverter;
 
     /**
      * Constructor to use by dependencies. Processes Update requests.
      */
     UpdateHandler() {
-        this.updateAssociationTranslator = new UpdateAssociationTranslator();
-        this.associationDescriptionTranslator = new AssociationDescriptionTranslator();
-        this.exceptionTranslator = new ExceptionTranslator();
+        this.initialUpdateHandler = new InitialUpdateHandler(SSM_CLIENT);
+        this.inProgressHandler = new InProgressHandler(SSM_CLIENT);
         this.requestToStringConverter = new ResourceHandlerRequestToStringConverter(new ResourceModelToStringConverter());
     }
 
     /**
      * Used for unit tests.
      *
-     * @param updateAssociationTranslator Translates ResourceModel objects into UpdateAssociation requests.
-     * @param associationDescriptionTranslator Translates AssociationDescription into ResourceModel objects.
-     * @param exceptionTranslator Translates service model exceptions.
+     * @param initialUpdateHandler     Concrete implementation of BaseHandler used to handle first Update requests.
+     * @param inProgressHandler        Concrete implementation of BaseHandler used to handle in-progress requests.
      * @param requestToStringConverter ResourceHandlerRequestToStringConverter used to convert requests to Strings.
      */
-    UpdateHandler(final UpdateAssociationTranslator updateAssociationTranslator,
-                  final AssociationDescriptionTranslator associationDescriptionTranslator,
-                  final ExceptionTranslator exceptionTranslator,
-                  final ResourceHandlerRequestToStringConverter requestToStringConverter) {
-        this.updateAssociationTranslator = updateAssociationTranslator;
-        this.associationDescriptionTranslator = associationDescriptionTranslator;
-        this.exceptionTranslator = exceptionTranslator;
+    UpdateHandler(
+        final BaseHandler<CallbackContext> initialUpdateHandler,
+        final BaseHandler<CallbackContext> inProgressHandler,
+        final ResourceHandlerRequestToStringConverter requestToStringConverter) {
+
+        this.initialUpdateHandler = initialUpdateHandler;
+        this.inProgressHandler = inProgressHandler;
         this.requestToStringConverter = requestToStringConverter;
     }
 
@@ -67,43 +56,10 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
 
         logger.log(String.format("Processing UpdateHandler request: %s", requestToStringConverter.convert(request)));
 
-        final ResourceModel requestModel = request.getDesiredResourceState();
-
-        final ProgressEvent<ResourceModel, CallbackContext> progressEvent = new ProgressEvent<>();
-        progressEvent.setResourceModel(request.getPreviousResourceState());
-        progressEvent.setStatus(OperationStatus.FAILED);
-
-        final String associationId = requestModel.getAssociationId();
-
-        if (StringUtils.isNullOrEmpty(associationId)) {
-            progressEvent.setErrorCode(HandlerErrorCode.InvalidRequest);
-            progressEvent.setMessage("AssociationId must be present to update the existing association.");
-            return progressEvent;
+        if (callbackContext == null) {
+            return initialUpdateHandler.handleRequest(proxy, request, callbackContext, logger);
+        } else {
+            return inProgressHandler.handleRequest(proxy, request, callbackContext, logger);
         }
-
-        final UpdateAssociationRequest updateAssociationRequest =
-            updateAssociationTranslator.resourceModelToRequest(requestModel);
-
-        try {
-            final AssociationDescription association =
-                proxy.injectCredentialsAndInvokeV2(updateAssociationRequest, SSM_CLIENT::updateAssociation)
-                    .associationDescription();
-
-            final ResourceModel updatedModel =
-                associationDescriptionTranslator.associationDescriptionToResourceModel(association);
-
-            progressEvent.setResourceModel(updatedModel);
-            progressEvent.setStatus(OperationStatus.SUCCESS);
-
-        } catch (Exception e) {
-            final BaseHandlerException cfnException = exceptionTranslator
-                .translateFromServiceException(e, updateAssociationRequest, requestModel);
-
-            logger.log(cfnException.getCause().getMessage());
-
-            throw cfnException;
-        }
-
-        return progressEvent;
     }
 }

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InitialUpdateHandlerTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/InitialUpdateHandlerTest.java
@@ -1,0 +1,281 @@
+package com.amazonaws.ssm.association;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.ssm.association.translator.AssociationDescriptionTranslator;
+import com.amazonaws.ssm.association.translator.ExceptionTranslator;
+import com.amazonaws.ssm.association.translator.request.UpdateAssociationTranslator;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.AssociationDescription;
+import software.amazon.awssdk.services.ssm.model.TooManyUpdatesException;
+import software.amazon.awssdk.services.ssm.model.UpdateAssociationRequest;
+import software.amazon.awssdk.services.ssm.model.UpdateAssociationResponse;
+import software.amazon.cloudformation.exceptions.CfnThrottlingException;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+import java.util.function.Function;
+
+@ExtendWith(MockitoExtension.class)
+class InitialUpdateHandlerTest {
+
+    private static final String DOCUMENT_NAME = "NewTestDocument";
+    private static final String ASSOCIATION_ID = "test-12345-associationId";
+    private static final String ASSOCIATION_NAME = "TestAssociation";
+    private static final String NEW_ASSOCIATION_NAME = "NewTestAssociation";
+
+    private InitialUpdateHandler handler;
+    @Mock
+    private SsmClient ssmClient;
+    @Mock
+    private AmazonWebServicesClientProxy proxy;
+    @Mock
+    private Logger logger;
+    @Mock
+    private UpdateAssociationTranslator updateAssociationTranslator;
+    @Mock
+    private AssociationDescriptionTranslator associationDescriptionTranslator;
+    @Mock
+    private ExceptionTranslator exceptionTranslator;
+    @Mock
+    private InProgressEventCreator inProgressEventCreator;
+
+    @BeforeEach
+    void setup() {
+        handler = new InitialUpdateHandler(ssmClient,
+            updateAssociationTranslator,
+            associationDescriptionTranslator,
+            exceptionTranslator,
+            inProgressEventCreator);
+    }
+
+    @Test
+    void defaultConstructorWorks() {
+        new InitialUpdateHandler(ssmClient);
+    }
+
+    @Test
+    void handleRequestWithAssociationIdPresentWithNoWaitForSuccess() {
+        final ResourceModel.ResourceModelBuilder resourceModelBuilder =
+            ResourceModel.builder()
+                .associationId(ASSOCIATION_ID)
+                .associationName(ASSOCIATION_NAME)
+                .name(DOCUMENT_NAME);
+
+        final ResourceModel previousModel = resourceModelBuilder.build();
+        final ResourceModel desiredModel = resourceModelBuilder
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final AssociationDescription associationDescription =
+            AssociationDescription.builder()
+                .associationId(desiredModel.getAssociationId())
+                .name(desiredModel.getName())
+                .associationName(desiredModel.getAssociationName())
+                .build();
+
+        final UpdateAssociationRequest expectedUpdateAssociationRequest =
+            UpdateAssociationRequest.builder()
+                .associationId(desiredModel.getAssociationId())
+                .name(desiredModel.getName())
+                .associationName(desiredModel.getAssociationName())
+                .build();
+
+        when(updateAssociationTranslator.resourceModelToRequest(desiredModel))
+            .thenReturn(expectedUpdateAssociationRequest);
+
+        when(associationDescriptionTranslator.associationDescriptionToResourceModel(associationDescription))
+            .thenReturn(desiredModel);
+
+        final UpdateAssociationResponse result =
+            UpdateAssociationResponse.builder()
+                .associationDescription(associationDescription)
+                .build();
+
+        when(
+            proxy.injectCredentialsAndInvokeV2(
+                eq(expectedUpdateAssociationRequest),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResponse>>any()))
+            .thenReturn(result);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        final ProgressEvent<ResourceModel, CallbackContext> expectedProgressEvent =
+            ProgressEvent.defaultSuccessHandler(desiredModel);
+
+        assertThat(response).isEqualTo(expectedProgressEvent);
+        verifyZeroInteractions(exceptionTranslator);
+    }
+
+    @Test
+    void handleRequestWithNoAssociationId() {
+        final ResourceModel desiredModel = ResourceModel.builder()
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+            .associationName(ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        final ProgressEvent<ResourceModel, CallbackContext> expectedProgressEvent =
+            ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModel(previousModel)
+                .status(OperationStatus.FAILED)
+                .errorCode(HandlerErrorCode.InvalidRequest)
+                .message("AssociationId must be present to update the existing association.")
+                .build();
+
+        assertThat(response).isEqualTo(expectedProgressEvent);
+        verifyZeroInteractions(proxy);
+        verifyZeroInteractions(associationDescriptionTranslator);
+        verifyZeroInteractions(exceptionTranslator);
+    }
+
+    @Test
+    void handleRequestThrowsTranslatedServiceException() {
+        final ResourceModel.ResourceModelBuilder resourceModelBuilder =
+            ResourceModel.builder()
+                .associationId(ASSOCIATION_ID)
+                .associationName(ASSOCIATION_NAME)
+                .name(DOCUMENT_NAME);
+
+        final ResourceModel previousModel = resourceModelBuilder.build();
+        final ResourceModel desiredModel = resourceModelBuilder
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final UpdateAssociationRequest expectedUpdateAssociationRequest =
+            UpdateAssociationRequest.builder()
+                .associationId(desiredModel.getAssociationId())
+                .name(desiredModel.getName())
+                .associationName(desiredModel.getAssociationName())
+                .build();
+
+        when(updateAssociationTranslator.resourceModelToRequest(desiredModel))
+            .thenReturn(expectedUpdateAssociationRequest);
+
+        final TooManyUpdatesException serviceException = TooManyUpdatesException.builder().build();
+
+        when(
+            proxy.injectCredentialsAndInvokeV2(
+                eq(expectedUpdateAssociationRequest),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResponse>>any()))
+            .thenThrow(serviceException);
+
+        when(
+            exceptionTranslator.translateFromServiceException(
+                serviceException,
+                expectedUpdateAssociationRequest,
+                desiredModel))
+            .thenReturn(new CfnThrottlingException("UpdateAssociation", serviceException));
+
+        Assertions.assertThrows(CfnThrottlingException.class, () -> {
+            handler.handleRequest(proxy, request, null, logger);
+        });
+        verify(exceptionTranslator)
+            .translateFromServiceException(
+                serviceException,
+                expectedUpdateAssociationRequest,
+                desiredModel);
+    }
+
+    @Test
+    void handleRequestWithWaitForSuccessPreviouslySet() {
+        final ResourceModel.ResourceModelBuilder resourceModelBuilder =
+            ResourceModel.builder()
+                .associationId(ASSOCIATION_ID)
+                .associationName(ASSOCIATION_NAME)
+                .name(DOCUMENT_NAME)
+                .waitForSuccessTimeoutSeconds(30);
+
+        final ResourceModel previousModel = resourceModelBuilder.build();
+        final ResourceModel desiredModel = resourceModelBuilder
+            .associationName(NEW_ASSOCIATION_NAME)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(desiredModel)
+            .previousResourceState(previousModel)
+            .build();
+
+        final AssociationDescription associationDescription =
+            AssociationDescription.builder()
+                .associationId(desiredModel.getAssociationId())
+                .name(desiredModel.getName())
+                .associationName(desiredModel.getAssociationName())
+                .build();
+
+        final UpdateAssociationRequest expectedUpdateAssociationRequest =
+            UpdateAssociationRequest.builder()
+                .associationId(desiredModel.getAssociationId())
+                .name(desiredModel.getName())
+                .associationName(desiredModel.getAssociationName())
+                .build();
+
+        when(updateAssociationTranslator.resourceModelToRequest(desiredModel))
+            .thenReturn(expectedUpdateAssociationRequest);
+
+        when(associationDescriptionTranslator.associationDescriptionToResourceModel(associationDescription))
+            .thenReturn(desiredModel);
+
+        final UpdateAssociationResponse result =
+            UpdateAssociationResponse.builder()
+                .associationDescription(associationDescription)
+                .build();
+
+        when(
+            proxy.injectCredentialsAndInvokeV2(
+                eq(expectedUpdateAssociationRequest),
+                ArgumentMatchers.<Function<UpdateAssociationRequest, UpdateAssociationResponse>>any()))
+            .thenReturn(result);
+
+        final CallbackContext inProgressContext =
+            CallbackContext.builder().associationId(ASSOCIATION_ID).remainingTimeoutSeconds(15).build();
+        final ProgressEvent<ResourceModel, CallbackContext> expectedProgressEvent =
+            ProgressEvent.defaultInProgressHandler(inProgressContext, 15, desiredModel);
+
+        when(inProgressEventCreator.nextInProgressEvent(desiredModel.getWaitForSuccessTimeoutSeconds(), desiredModel))
+            .thenReturn(expectedProgressEvent);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isEqualTo(expectedProgressEvent);
+        verifyZeroInteractions(exceptionTranslator);
+    }
+}


### PR DESCRIPTION
*Description of changes:*
* Adding progress chaining to UpdateHandler for AWS::SSM::Association
* I had to change annotations for CallbackContext, as the CFN orchestrator seems to require a default no-args constructor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
