### PR TITLE
add iam:PassRole permission for Create and Update document handlers

### DIFF
--- a/aws-ssm-document/aws-ssm-document.json
+++ b/aws-ssm-document/aws-ssm-document.json
@@ -161,7 +161,8 @@
         "create": {
             "permissions": [
                 "ssm:CreateDocument",
-                "s3:GetObject"
+                "s3:GetObject",
+                "iam:PassRole"
             ]
         },
         "read": {
@@ -175,7 +176,8 @@
                 "s3:GetObject",
                 "ssm:AddTagsToResource",
                 "ssm:RemoveTagsFromResource",
-                "ssm:ListTagsForResource"
+                "ssm:ListTagsForResource",
+                "iam:PassRole"
             ]
         },
         "delete": {

--- a/aws-ssm-document/resource-role.yaml
+++ b/aws-ssm-document/resource-role.yaml
@@ -23,6 +23,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "iam:PassRole"
                 - "s3:GetObject"
                 - "ssm:AddTagsToResource"
                 - "ssm:CreateDocument"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some automation documents use iam:PassRole permissions and for those documents Cloudformation resource provider execution role would require iam:PassRole permission: https://docs.aws.amazon.com/systems-manager/latest/userguide/automation-permissions.html#automation-passpolicy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
