### PR TITLE
Make document Content required attribute, handle throttling

### DIFF
--- a/aws-ssm-document/aws-ssm-document.json
+++ b/aws-ssm-document/aws-ssm-document.json
@@ -81,8 +81,7 @@
             "type": [
                 "object",
                 "string"
-            ],
-            "minLength": 1
+            ]
         },
         "Attachments": {
             "description": "A list of key and value pairs that describe attachments to a version of a document.",
@@ -149,7 +148,9 @@
         }
     },
     "additionalProperties": false,
-    "required": [],
+    "required": [
+        "Content"
+    ],
     "createOnlyProperties": [
         "/properties/Name",
         "/properties/DocumentType"

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentExceptionTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentExceptionTranslator.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.services.ssm.model.AutomationDefinitionVersionNotF
 import software.amazon.awssdk.services.ssm.model.DocumentAlreadyExistsException;
 import software.amazon.awssdk.services.ssm.model.DocumentLimitExceededException;
 import software.amazon.awssdk.services.ssm.model.DocumentVersionLimitExceededException;
+import software.amazon.awssdk.services.ssm.model.InternalServerErrorException;
 import software.amazon.awssdk.services.ssm.model.InvalidDocumentContentException;
 import software.amazon.awssdk.services.ssm.model.InvalidDocumentException;
 import software.amazon.awssdk.services.ssm.model.InvalidDocumentSchemaVersionException;
@@ -15,7 +16,9 @@ import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
+import software.amazon.cloudformation.exceptions.CfnThrottlingException;
 
 import lombok.NonNull;
 
@@ -52,6 +55,10 @@ class DocumentExceptionTranslator {
 
             return new CfnNotFoundException(ResourceModel.TYPE_NAME, documentName);
 
+        } else if (e.isThrottlingException()) {
+            return new CfnThrottlingException(operationName, e);
+        } else if (e instanceof InternalServerErrorException) {
+            return new CfnServiceInternalErrorException(operationName, e);
         } else if (e.statusCode() == GENERIC_USER_ERROR_STATUS_CODE) {
             return new CfnInvalidRequestException(e.getMessage(), e);
         }

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentExceptionTranslatorTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentExceptionTranslatorTest.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.ssm.model.AutomationDefinitionNotFoundExc
 import software.amazon.awssdk.services.ssm.model.DocumentAlreadyExistsException;
 import software.amazon.awssdk.services.ssm.model.DocumentLimitExceededException;
 import software.amazon.awssdk.services.ssm.model.DocumentVersionLimitExceededException;
+import software.amazon.awssdk.services.ssm.model.InternalServerErrorException;
 import software.amazon.awssdk.services.ssm.model.InvalidDocumentContentException;
 import software.amazon.awssdk.services.ssm.model.InvalidDocumentException;
 import software.amazon.awssdk.services.ssm.model.InvalidDocumentVersionException;
@@ -19,7 +20,9 @@ import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnServiceInternalErrorException;
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
+import software.amazon.cloudformation.exceptions.CfnThrottlingException;
 
 @ExtendWith(MockitoExtension.class)
 public class DocumentExceptionTranslatorTest {
@@ -52,7 +55,16 @@ public class DocumentExceptionTranslatorTest {
 
         Assertions.assertTrue(unitUnderTest.getCfnException(AutomationDefinitionNotFoundException.builder().build(), SAMPLE_DOCUMENT_NAME, SAMPLE_OPERATION_NAME) instanceof CfnInvalidRequestException);
 
+        Assertions.assertTrue(unitUnderTest.getCfnException(InternalServerErrorException.builder().build(), SAMPLE_DOCUMENT_NAME, SAMPLE_OPERATION_NAME) instanceof CfnServiceInternalErrorException);
+
         Assertions.assertTrue(unitUnderTest.getCfnException(ssmException, SAMPLE_DOCUMENT_NAME, SAMPLE_OPERATION_NAME) instanceof CfnGeneralServiceException);
+    }
+
+    @Test
+    public void testGetCfnException_ThrottlingException_verifyExceptionsReturned() {
+        Mockito.when(ssmException.isThrottlingException()).thenReturn(true);
+
+        Assertions.assertTrue(unitUnderTest.getCfnException(ssmException, SAMPLE_DOCUMENT_NAME, SAMPLE_OPERATION_NAME) instanceof CfnThrottlingException);
     }
 
     @Test


### PR DESCRIPTION
Make document Content required attribute, handle throttling and internalServerError exceptions.

*Issue #, if available:*

*Description of changes:*
Make document Content required attribute, handle throttling and internalServerError exceptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
