### PR TITLE
Modify retry policy to better handle throttling

### DIFF
--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/ClientBuilder.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/ClientBuilder.java
@@ -2,14 +2,41 @@ package com.amazonaws.ssm.document;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import java.time.Duration;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.internal.retry.SdkDefaultRetrySetting;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.core.retry.backoff.BackoffStrategy;
+import software.amazon.awssdk.core.retry.backoff.EqualJitterBackoffStrategy;
+import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.cloudformation.LambdaWrapper;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ClientBuilder {
+
+    private static final BackoffStrategy BACKOFF_THROTTLING_STRATEGY =
+        EqualJitterBackoffStrategy.builder()
+            .baseDelay(Duration.ofMillis(1000)) //1st retry is ~1 sec
+            .maxBackoffTime(SdkDefaultRetrySetting.MAX_BACKOFF) //default is 20s
+            .build();
+
+    private static final RetryPolicy RETRY_POLICY =
+        RetryPolicy.builder()
+            .numRetries(6)
+            .retryCondition(RetryCondition.defaultRetryCondition())
+            .throttlingBackoffStrategy(BACKOFF_THROTTLING_STRATEGY)
+            .build();
+
+    private static final ClientOverrideConfiguration CLIENT_OVERRIDE_CONFIGURATION =
+        ClientOverrideConfiguration.builder()
+            .retryPolicy(RETRY_POLICY)
+            .build();
+
     static SsmClient getClient() {
         return SsmClient.builder()
                 .httpClient(LambdaWrapper.HTTP_CLIENT)
+                .overrideConfiguration(CLIENT_OVERRIDE_CONFIGURATION)
                 .build();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modify retryPolicy for ssmClient so that throttling can be retried more number of times to give the resource a better chance at succeeded create/update/delete request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
