### PR TITLE
Make Document Content and related attributes immutable

### DIFF
--- a/aws-ssm-document/aws-ssm-document.json
+++ b/aws-ssm-document/aws-ssm-document.json
@@ -152,8 +152,14 @@
         "Content"
     ],
     "createOnlyProperties": [
+        "/properties/Content",
+        "/properties/Attachments",
         "/properties/Name",
-        "/properties/DocumentType"
+        "/properties/VersionName",
+        "/properties/DocumentType",
+        "/properties/DocumentFormat",
+        "/properties/TargetType",
+        "/properties/Requires"
     ],
     "primaryIdentifier": [
         "/properties/Name"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make Document Content CreateOnly property to be inline with the existing behavior in Cloudformation https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-document.html

Making Document content CreateOnly would trigger replacement instead of updating the existing document. Other properties that UpdateDocument API supports also need to be set to CreateOnly to trigger replacement instead of true update: https://docs.aws.amazon.com/cli/latest/reference/ssm/update-document.html
DocumentFormat, DocumentType, TargetType, VersionName, Attachments

DocumentRequires is not supported by UpdateDocument API, so it can only be a CreateOnly property

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
