### PR TITLE
Do not fail  if only stack level tags are provided

### DIFF
--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/CreateHandler.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/CreateHandler.java
@@ -52,7 +52,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
     public CreateHandler() {
         this(DocumentModelTranslator.getInstance(), StabilizationProgressRetriever.getInstance(),
                 DocumentExceptionTranslator.getInstance(), TagUtil.getInstance(), ClientBuilder.getClient(),
-            SafeLogger.getInstance());
+                SafeLogger.getInstance());
     }
 
     /**
@@ -60,10 +60,10 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
      */
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-        final AmazonWebServicesClientProxy proxy,
-        final ResourceHandlerRequest<ResourceModel> request,
-        final CallbackContext callbackContext,
-        final Logger logger) {
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
 
         final CallbackContext context = callbackContext == null ? CallbackContext.builder().build() : callbackContext;
         final ResourceModel model = request.getDesiredResourceState();
@@ -78,7 +78,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
         try {
             createDocumentRequest =
                     documentModelTranslator.generateCreateDocumentRequest(model, request.getSystemTags(),
-                        request.getDesiredResourceTags(), request.getClientRequestToken());
+                            request.getDesiredResourceTags(), request.getClientRequestToken());
 
         } catch (final InvalidDocumentContentException e) {
             throw new CfnInvalidRequestException(e.getMessage(), e);
@@ -93,12 +93,12 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             context.setStabilizationRetriesRemaining(NUMBER_OF_DOCUMENT_CREATE_POLL_RETRIES);
 
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                .resourceModel(model)
-                .status(OperationStatus.IN_PROGRESS)
-                .message(response.documentDescription().statusInformation())
-                .callbackContext(context)
-                .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
-                .build();
+                    .resourceModel(model)
+                    .status(OperationStatus.IN_PROGRESS)
+                    .message(response.documentDescription().statusInformation())
+                    .callbackContext(context)
+                    .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
+                    .build();
         } catch (final SsmException e) {
             throw exceptionTranslator.getCfnException(e, model.getName(), OPERATION_NAME, logger);
         }
@@ -115,6 +115,8 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
             if (!tagUtil.shouldSoftFailTags(null, model.getTags(), e)) {
                 throw exceptionTranslator.getCfnException(e, model.getName(), OPERATION_NAME, logger);
             }
+            logger.log(String.format("Soft fail adding tags during create of document %s",
+                    createDocumentRequest.name()));
         }
 
         final CreateDocumentRequest createDocumentRequestWithoutTags = createDocumentRequest.toBuilder().tags(ImmutableList.of()).build();

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/UpdateHandler.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/UpdateHandler.java
@@ -50,16 +50,16 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
     @VisibleForTesting
     UpdateHandler() {
         this(DocumentModelTranslator.getInstance(), StabilizationProgressRetriever.getInstance(),
-            TagUpdater.getInstance(),
-            DocumentExceptionTranslator.getInstance(), ClientBuilder.getClient(), SafeLogger.getInstance());
+                TagUpdater.getInstance(),
+                DocumentExceptionTranslator.getInstance(), ClientBuilder.getClient(), SafeLogger.getInstance());
     }
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-        final AmazonWebServicesClientProxy proxy,
-        final ResourceHandlerRequest<ResourceModel> request,
-        final CallbackContext callbackContext,
-        final Logger logger) {
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final Logger logger) {
 
         final CallbackContext context = callbackContext == null ? CallbackContext.builder().build() : callbackContext;
         final ResourceModel model = request.getDesiredResourceState();
@@ -71,15 +71,15 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         try {
             logger.log("update tags request for document name: " + model.getName());
             tagUpdater.updateTags(model.getName(), request.getPreviousResourceTags(), request.getDesiredResourceTags(),
-                previousModel.getTags(), model.getTags(),
-                ssmClient, proxy);
+                    previousModel.getTags(), model.getTags(),
+                    ssmClient, proxy, logger);
 
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                .resourceModel(model)
-                .status(OperationStatus.SUCCESS)
-                .callbackContext(context)
-                .callbackDelaySeconds(0)
-                .build();
+                    .resourceModel(model)
+                    .status(OperationStatus.SUCCESS)
+                    .callbackContext(context)
+                    .callbackDelaySeconds(0)
+                    .build();
         } catch (final SsmException e) {
             throw exceptionTranslator.getCfnException(e, model.getName(), OPERATION_NAME, logger);
         }

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/UpdateHandler.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/UpdateHandler.java
@@ -1,23 +1,12 @@
 package com.amazonaws.ssm.document;
 
-import java.util.logging.LogManager;
 import com.amazonaws.ssm.document.tags.TagUpdater;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.services.ssm.SsmClient;
-import software.amazon.awssdk.services.ssm.model.DuplicateDocumentContentException;
-import software.amazon.awssdk.services.ssm.model.DuplicateDocumentVersionNameException;
-import software.amazon.awssdk.services.ssm.model.GetDocumentRequest;
-import software.amazon.awssdk.services.ssm.model.GetDocumentResponse;
-import software.amazon.awssdk.services.ssm.model.InvalidDocumentSchemaVersionException;
 import software.amazon.awssdk.services.ssm.model.SsmException;
-import software.amazon.awssdk.services.ssm.model.UpdateDocumentRequest;
-import software.amazon.awssdk.services.ssm.model.UpdateDocumentResponse;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -74,13 +63,16 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
 
         final CallbackContext context = callbackContext == null ? CallbackContext.builder().build() : callbackContext;
         final ResourceModel model = request.getDesiredResourceState();
+        final ResourceModel previousModel = request.getPreviousResourceState();
 
         safeLogger.safeLogDocumentInformation(model, callbackContext, request.getAwsAccountId(), request.getSystemTags(), logger);
 
         // Only Tags are handled in Update Handler. Other properties of the Document resource are CreateOnly.
         try {
             logger.log("update tags request for document name: " + model.getName());
-            tagUpdater.updateTags(model.getName(), request.getDesiredResourceTags(), ssmClient, proxy);
+            tagUpdater.updateTags(model.getName(), request.getPreviousResourceTags(), request.getDesiredResourceTags(),
+                previousModel.getTags(), model.getTags(),
+                ssmClient, proxy);
 
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
                 .resourceModel(model)

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagUpdater.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagUpdater.java
@@ -11,39 +11,94 @@ import com.google.common.collect.Sets;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.SsmException;
 import software.amazon.awssdk.services.ssm.model.Tag;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 
 @RequiredArgsConstructor
 public class TagUpdater {
 
+
     private static TagUpdater INSTANCE;
 
     @NonNull
     private final TagClient tagClient;
 
+    @NonNull
+    private final TagUtil tagUtil;
+
     public static TagUpdater getInstance() {
         if (INSTANCE == null) {
-            INSTANCE = new TagUpdater(new TagClient());
+            INSTANCE = new TagUpdater(new TagClient(), TagUtil.getInstance());
         }
 
         return INSTANCE;
     }
 
-    public void updateTags(@NonNull final String documentName,
-                    @Nullable final Map<String, String> resourceTags,
-                    @NonNull final SsmClient ssmClient,
-                    @NonNull final AmazonWebServicesClientProxy proxy) {
-        if (resourceTags == null) return;
+    public void createTags(@NonNull final String documentName,
+                           @Nullable final Map<String, String> desiredResourceTagsFromRequest,
+                           @Nullable final List<com.amazonaws.ssm.document.Tag> resourceModelTags,
+                           @NonNull final SsmClient ssmClient,
+                           @NonNull final AmazonWebServicesClientProxy proxy) {
+        if (desiredResourceTagsFromRequest == null) return;
 
-        final List<Tag> requestedTags = translateTags(resourceTags);
-        final List<Tag> existingTags = tagClient.listTags(documentName, ssmClient, proxy);
+        final List<Tag> tagsToCreate = translateTags(desiredResourceTagsFromRequest);
+
+        addTags(tagsToCreate, documentName, null, resourceModelTags, ssmClient, proxy);
+    }
+
+    public void updateTags(@NonNull final String documentName,
+                           @Nullable final Map<String, String> desiredResourceTagsFromPreviousRequest,
+                           @Nullable final Map<String, String> desiredResourceTagsFromCurrentRequest,
+                           @Nullable final List<com.amazonaws.ssm.document.Tag> previousResourceModelTags,
+                           @Nullable final List<com.amazonaws.ssm.document.Tag> currentResourceModelTags,
+                           @NonNull final SsmClient ssmClient,
+                           @NonNull final AmazonWebServicesClientProxy proxy) {
+
+
+        final List<Tag> existingTags = desiredResourceTagsFromPreviousRequest == null ? ImmutableList.of()
+            : translateTags(desiredResourceTagsFromPreviousRequest);
+
+        final List<Tag> requestedTags = desiredResourceTagsFromCurrentRequest == null ? ImmutableList.of()
+            : translateTags(desiredResourceTagsFromCurrentRequest);
 
         final List<Tag> tagsToAdd = getTagsToAdd(requestedTags, existingTags);
         final List<Tag> tagsToRemove = getTagsToRemove(requestedTags, existingTags);
 
-        tagClient.removeTags(tagsToRemove, documentName, ssmClient, proxy);
-        tagClient.addTags(tagsToAdd, documentName, ssmClient, proxy);
+        removeTags(tagsToRemove, documentName, previousResourceModelTags, currentResourceModelTags, ssmClient, proxy);
+        addTags(tagsToAdd, documentName, previousResourceModelTags, currentResourceModelTags, ssmClient, proxy);
+    }
+
+    private void addTags(final List<Tag> tagsToAdd, final String documentName,
+                         final List<com.amazonaws.ssm.document.Tag> previousResourceModelTags,
+                         final List<com.amazonaws.ssm.document.Tag> currentResourceModelTags,
+                         final SsmClient ssmClient,
+                         final AmazonWebServicesClientProxy proxy) {
+        try {
+            tagClient.addTags(tagsToAdd, documentName, ssmClient, proxy);
+        } catch (final SsmException e) {
+            if (tagUtil.shouldSoftFailTags(previousResourceModelTags, currentResourceModelTags, e)) {
+                return;
+            }
+
+            throw e;
+        }
+    }
+
+    private void removeTags(final List<Tag> tagsToRemove, final String documentName,
+                         final List<com.amazonaws.ssm.document.Tag> previousResourceModelTags,
+                         final List<com.amazonaws.ssm.document.Tag> currentResourceModelTags,
+                         final SsmClient ssmClient,
+                         final AmazonWebServicesClientProxy proxy) {
+        try {
+            tagClient.removeTags(tagsToRemove, documentName, ssmClient, proxy);
+        } catch (final SsmException e) {
+            if (tagUtil.shouldSoftFailTags(previousResourceModelTags, currentResourceModelTags, e)) {
+                return;
+            }
+
+            throw e;
+        }
     }
 
     private List<Tag> getTagsToAdd(List<Tag> requestedTags, List<Tag> existingTags) {

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagUtil.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagUtil.java
@@ -1,0 +1,46 @@
+package com.amazonaws.ssm.document.tags;
+
+import com.amazonaws.ssm.document.Tag;
+import lombok.NonNull;
+import javax.annotation.Nullable;
+import java.util.List;
+import software.amazon.awssdk.services.ssm.model.SsmException;
+
+public class TagUtil {
+
+    private static final String ACCESS_DENIED_ERROR_CODE = "AccessDeniedException";
+
+    private static TagUtil INSTANCE;
+
+    public static TagUtil getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new TagUtil();
+        }
+
+        return INSTANCE;
+    }
+
+    /**
+     * During resource create or update, customer may not permissions to Tagging APIs, but the cloudformation has a concept of stack level tags.
+     * When tags are applied at stack level, it doesn't necessarily mean that customer is intending to apply tags to this particular resource.
+     * In this scenario, we do a best effort to apply the stack level tags to resource and not fail even if customer does not have permissions.
+     *
+     * But if customer provided resource level tags, we do a hard fail if customer does not have permissions.
+     *
+     * @param previousResourceModelTags tags provided previously before update.
+     * @param currentResourceModelTags current resource model tags.
+     * @param exception Exception occurred.
+     * @return if we should do best effort or hard fail.
+     */
+    public boolean shouldSoftFailTags(@Nullable final List<Tag> previousResourceModelTags,
+                                      @Nullable final List<com.amazonaws.ssm.document.Tag> currentResourceModelTags,
+                                      @NonNull final SsmException exception) {
+        final boolean isAccessDeniedException = ACCESS_DENIED_ERROR_CODE.equalsIgnoreCase(exception.awsErrorDetails().errorCode());
+
+        // If customer provided only stack level tags and not resource level tags for the Document resource, do not fail on AccessDenied error.
+        final boolean hasCustomerNotSpecifiedModelTags = (previousResourceModelTags == null || previousResourceModelTags.isEmpty())
+            && (currentResourceModelTags == null || currentResourceModelTags.isEmpty());
+
+        return isAccessDeniedException && hasCustomerNotSpecifiedModelTags;
+    }
+}

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagUtil.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/tags/TagUtil.java
@@ -1,11 +1,15 @@
 package com.amazonaws.ssm.document.tags;
 
 import com.amazonaws.ssm.document.Tag;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import javax.annotation.Nullable;
 import java.util.List;
 import software.amazon.awssdk.services.ssm.model.SsmException;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TagUtil {
 
     private static final String ACCESS_DENIED_ERROR_CODE = "AccessDeniedException";
@@ -21,7 +25,7 @@ public class TagUtil {
     }
 
     /**
-     * During resource create or update, customer may not permissions to Tagging APIs, but the cloudformation has a concept of stack level tags.
+     * During resource create or update, customer may not have permissions to Tagging APIs, but the cloudformation has a concept of stack level tags.
      * When tags are applied at stack level, it doesn't necessarily mean that customer is intending to apply tags to this particular resource.
      * In this scenario, we do a best effort to apply the stack level tags to resource and not fail even if customer does not have permissions.
      *
@@ -33,13 +37,13 @@ public class TagUtil {
      * @return if we should do best effort or hard fail.
      */
     public boolean shouldSoftFailTags(@Nullable final List<Tag> previousResourceModelTags,
-                                      @Nullable final List<com.amazonaws.ssm.document.Tag> currentResourceModelTags,
+                                      @Nullable final List<Tag> currentResourceModelTags,
                                       @NonNull final SsmException exception) {
         final boolean isAccessDeniedException = ACCESS_DENIED_ERROR_CODE.equalsIgnoreCase(exception.awsErrorDetails().errorCode());
 
         // If customer provided only stack level tags and not resource level tags for the Document resource, do not fail on AccessDenied error.
         final boolean hasCustomerNotSpecifiedModelTags = (previousResourceModelTags == null || previousResourceModelTags.isEmpty())
-            && (currentResourceModelTags == null || currentResourceModelTags.isEmpty());
+                && (currentResourceModelTags == null || currentResourceModelTags.isEmpty());
 
         return isAccessDeniedException && hasCustomerNotSpecifiedModelTags;
     }

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/UpdateHandlerTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/UpdateHandlerTest.java
@@ -40,19 +40,19 @@ public class UpdateHandlerTest {
             "description", "Join instances to an AWS Directory Service domain."
     );
     private static final Map<String, Object> SAMPLE_PREVIOUS_DOCUMENT_CONTENT = ImmutableMap.of(
-        "schemaVersion", "1.1",
-        "description", "Join instances to an AWS Directory Service domain."
+            "schemaVersion", "1.1",
+            "description", "Join instances to an AWS Directory Service domain."
     );
     private static final Map<String, String> SAMPLE_SYSTEM_TAGS = ImmutableMap.of("aws:cloudformation:stack-name", "testStack");
     private static final Map<String, String> SAMPLE_DESIRED_RESOURCE_TAGS = ImmutableMap.of("tagKey1", "tagValue1");
     private static final Map<String, String> SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS = ImmutableMap.of("tagKey2", "tagValue2");
     private static final List<Tag> SAMPLE_PREVIOUS_MODEL_TAGS = ImmutableList.of(
-        Tag.builder().key("tagModelKey1").value("tagModelValue1").build(),
-        Tag.builder().key("tagModelKey2").value("tagModelValue2").build()
+            Tag.builder().key("tagModelKey1").value("tagModelValue1").build(),
+            Tag.builder().key("tagModelKey2").value("tagModelValue2").build()
     );
     private static final List<Tag> SAMPLE_MODEL_TAGS = ImmutableList.of(
-        Tag.builder().key("tagModelKey3").value("tagModelValue3").build(),
-        Tag.builder().key("tagModelKey4").value("tagModelValue4").build()
+            Tag.builder().key("tagModelKey3").value("tagModelValue3").build(),
+            Tag.builder().key("tagModelKey4").value("tagModelValue4").build()
     );
     private static final String SAMPLE_REQUEST_TOKEN = "sampleRequestToken";
     private static final UpdateDocumentRequest SAMPLE_UPDATE_DOCUMENT_REQUEST = UpdateDocumentRequest.builder()
@@ -66,10 +66,10 @@ public class UpdateHandlerTest {
             .tags(SAMPLE_MODEL_TAGS)
             .build();
     private static final ResourceModel SAMPLE_PREVIOUS_RESOURCE_MODEL = ResourceModel.builder()
-        .name(SAMPLE_DOCUMENT_NAME)
-        .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
-        .tags(SAMPLE_PREVIOUS_MODEL_TAGS)
-        .build();
+            .name(SAMPLE_DOCUMENT_NAME)
+            .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+            .tags(SAMPLE_PREVIOUS_MODEL_TAGS)
+            .build();
     private static final ResourceHandlerRequest<ResourceModel> SAMPLE_RESOURCE_HANDLER_REQUEST = ResourceHandlerRequest.<ResourceModel>builder()
             .systemTags(SAMPLE_SYSTEM_TAGS)
             .desiredResourceTags(SAMPLE_DESIRED_RESOURCE_TAGS)
@@ -131,8 +131,8 @@ public class UpdateHandlerTest {
     public void testHandleRequest_DocumentUpdateTagsSuccess_VerifyResponse() {
 
         final ResourceModel expectedModel = ResourceModel.builder().name(SAMPLE_DOCUMENT_NAME).content(SAMPLE_DOCUMENT_CONTENT)
-            .tags(SAMPLE_MODEL_TAGS)
-            .build();
+                .tags(SAMPLE_MODEL_TAGS)
+                .build();
         final CallbackContext expectedCallbackContext = CallbackContext.builder().build();
 
         final ProgressEvent<ResourceModel, CallbackContext> expectedResponse = ProgressEvent.<ResourceModel, CallbackContext>builder()
@@ -147,14 +147,14 @@ public class UpdateHandlerTest {
 
         Assertions.assertEquals(expectedResponse, response);
         Mockito.verify(tagUpdater).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS, SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
-            SAMPLE_MODEL_TAGS, ssmClient, proxy);
+                SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
         verify(safeLogger).safeLogDocumentInformation(SAMPLE_RESOURCE_MODEL, null, SAMPLE_ACCOUNT_ID, SAMPLE_SYSTEM_TAGS, logger);
     }
 
     @Test
     public void testHandleRequest_DocumentUpdateTagsThrowsException_VerifyResponse() {
         doThrow(ssmException).when(tagUpdater).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS,
-            SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy);
+                SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
 
         when(exceptionTranslator.getCfnException(ssmException, SAMPLE_DOCUMENT_NAME, OPERATION_NAME, logger)).thenReturn(cfnException);
 

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/tags/TagUpdaterTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/tags/TagUpdaterTest.java
@@ -16,42 +16,43 @@ import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.model.SsmException;
 import software.amazon.awssdk.services.ssm.model.Tag;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
 
 @ExtendWith(MockitoExtension.class)
 public class TagUpdaterTest {
 
     private static final String SAMPLE_DOCUMENT_NAME = "testDocument";
     private static final Map<String, String> SAMPLE_RESOURCE_REQUEST_TAGS = ImmutableMap.of(
-        "tagKey1", "tagValue1",
-        "tagKey5", "tagValue5",
-        "tagKey6", "tagValue6"
+            "tagKey1", "tagValue1",
+            "tagKey5", "tagValue5",
+            "tagKey6", "tagValue6"
     );
 
     private static final List<Tag> SAMPLE_RESOURCE_REQUEST_TAGS_SSM_FORMAT = ImmutableList.of(
-        Tag.builder().key("tagKey1").value("tagValue1").build(),
-        Tag.builder().key("tagKey5").value("tagValue5").build(),
-        Tag.builder().key("tagKey6").value("tagValue6").build()
+            Tag.builder().key("tagKey1").value("tagValue1").build(),
+            Tag.builder().key("tagKey5").value("tagValue5").build(),
+            Tag.builder().key("tagKey6").value("tagValue6").build()
     );
 
     private static final List<Tag> SAMPLE_EXISTING_TAGS = ImmutableList.of(
-        Tag.builder().key("tagKey1").value("tagValue1").build(),
-        Tag.builder().key("tagKey2").value("tagValue2").build(),
-        Tag.builder().key("tagKey3").value("tagValue3").build()
+            Tag.builder().key("tagKey1").value("tagValue1").build(),
+            Tag.builder().key("tagKey2").value("tagValue2").build(),
+            Tag.builder().key("tagKey3").value("tagValue3").build()
     );
 
     private static final Map<String, String> SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS = ImmutableMap.of(
-        "tagKey1", "tagValue1",
-        "tagKey2", "tagValue2",
-        "tagKey3", "tagValue3"
+            "tagKey1", "tagValue1",
+            "tagKey2", "tagValue2",
+            "tagKey3", "tagValue3"
     );
 
     private static final List<com.amazonaws.ssm.document.Tag> SAMPLE_PREVIOUS_MODEL_TAGS = ImmutableList.of(
-        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey1").value("tagModelValue1").build(),
-        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey2").value("tagModelValue2").build()
+            com.amazonaws.ssm.document.Tag.builder().key("tagModelKey1").value("tagModelValue1").build(),
+            com.amazonaws.ssm.document.Tag.builder().key("tagModelKey2").value("tagModelValue2").build()
     );
     private static final List<com.amazonaws.ssm.document.Tag> SAMPLE_MODEL_TAGS = ImmutableList.of(
-        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey3").value("tagModelValue3").build(),
-        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey4").value("tagModelValue4").build()
+            com.amazonaws.ssm.document.Tag.builder().key("tagModelKey3").value("tagModelValue3").build(),
+            com.amazonaws.ssm.document.Tag.builder().key("tagModelKey4").value("tagModelValue4").build()
     );
 
     @Mock
@@ -59,6 +60,9 @@ public class TagUpdaterTest {
 
     @Mock
     private AmazonWebServicesClientProxy proxy;
+
+    @Mock
+    private Logger logger;
 
     @Mock
     private TagClient tagClient;
@@ -80,7 +84,7 @@ public class TagUpdaterTest {
     public void testUpdateTags_existingTagsIsEmpty_verifyCalls() {
 
         unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, ImmutableMap.of(), SAMPLE_RESOURCE_REQUEST_TAGS,
-            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy);
+                SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
 
         verifyTagClientCalls(SAMPLE_RESOURCE_REQUEST_TAGS_SSM_FORMAT, ImmutableList.of());
     }
@@ -89,7 +93,7 @@ public class TagUpdaterTest {
     public void testUpdateTags_requestedTagsIsEmpty_verifyCalls() {
 
         unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, ImmutableMap.of(),
-            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy);
+                SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
 
         // Expected tags to add
         final List<Tag> expectedTagsToAdd = ImmutableList.of(
@@ -97,9 +101,9 @@ public class TagUpdaterTest {
 
         // expected tags to remove
         final List<Tag> expectedTagsToRemove = ImmutableList.of(
-            Tag.builder().key("tagKey1").value("tagValue1").build(),
-            Tag.builder().key("tagKey2").value("tagValue2").build(),
-            Tag.builder().key("tagKey3").value("tagValue3").build()
+                Tag.builder().key("tagKey1").value("tagValue1").build(),
+                Tag.builder().key("tagKey2").value("tagValue2").build(),
+                Tag.builder().key("tagKey3").value("tagValue3").build()
         );
 
         verifyTagClientCalls(expectedTagsToAdd, expectedTagsToRemove);
@@ -110,46 +114,46 @@ public class TagUpdaterTest {
 
         // Expected tags to add
         final List<Tag> expectedTagsToAdd = ImmutableList.of(
-            Tag.builder().key("tagKey5").value("tagValue5").build(),
-            Tag.builder().key("tagKey6").value("tagValue6").build()
+                Tag.builder().key("tagKey5").value("tagValue5").build(),
+                Tag.builder().key("tagKey6").value("tagValue6").build()
         );
 
         // expected tags to remove
         final List<Tag> expectedTagsToRemove = ImmutableList.of(
-            Tag.builder().key("tagKey2").value("tagValue2").build(),
-            Tag.builder().key("tagKey3").value("tagValue3").build()
+                Tag.builder().key("tagKey2").value("tagValue2").build(),
+                Tag.builder().key("tagKey3").value("tagValue3").build()
         );
 
         unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, SAMPLE_RESOURCE_REQUEST_TAGS,
-            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy);
+                SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
 
         verifyTagClientCalls(expectedTagsToAdd, expectedTagsToRemove);
-   }
+    }
 
     @Test
     public void testUpdateTags_existingTagKeyIsUpdated_verifyTagsAddedAndRemoved() {
         final Map<String, String> SAMPLE_RESOURCE_REQUEST_TAGS = ImmutableMap.of(
-            "tagKey1", "tagValue2",
-            "tagKey5", "tagValue5",
-            "tagKey6", "tagValue6"
+                "tagKey1", "tagValue2",
+                "tagKey5", "tagValue5",
+                "tagKey6", "tagValue6"
         );
 
         // Expected tags to add
         final List<Tag> expectedTagsToAdd = ImmutableList.of(
-            Tag.builder().key("tagKey1").value("tagValue2").build(),
-            Tag.builder().key("tagKey5").value("tagValue5").build(),
-            Tag.builder().key("tagKey6").value("tagValue6").build()
+                Tag.builder().key("tagKey1").value("tagValue2").build(),
+                Tag.builder().key("tagKey5").value("tagValue5").build(),
+                Tag.builder().key("tagKey6").value("tagValue6").build()
         );
 
         // expected tags to remove
         final List<Tag> expectedTagsToRemove = ImmutableList.of(
-            Tag.builder().key("tagKey1").value("tagValue1").build(),
-            Tag.builder().key("tagKey2").value("tagValue2").build(),
-            Tag.builder().key("tagKey3").value("tagValue3").build()
+                Tag.builder().key("tagKey1").value("tagValue1").build(),
+                Tag.builder().key("tagKey2").value("tagValue2").build(),
+                Tag.builder().key("tagKey3").value("tagValue3").build()
         );
 
         unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, SAMPLE_RESOURCE_REQUEST_TAGS,
-            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy);
+                SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
 
         verifyTagClientCalls(expectedTagsToAdd, expectedTagsToRemove);
     }
@@ -157,23 +161,23 @@ public class TagUpdaterTest {
     @Test
     public void testUpdateTags_addTagsAPIAccessDenied_shouldSoftFail_verifyTagsAddedAndRemoved() {
         final Map<String, String> SAMPLE_RESOURCE_REQUEST_TAGS = ImmutableMap.of(
-            "tagKey1", "tagValue2",
-            "tagKey5", "tagValue5",
-            "tagKey6", "tagValue6"
+                "tagKey1", "tagValue2",
+                "tagKey5", "tagValue5",
+                "tagKey6", "tagValue6"
         );
 
         // Expected tags to add
         final List<Tag> expectedTagsToAdd = ImmutableList.of(
-            Tag.builder().key("tagKey1").value("tagValue2").build(),
-            Tag.builder().key("tagKey5").value("tagValue5").build(),
-            Tag.builder().key("tagKey6").value("tagValue6").build()
+                Tag.builder().key("tagKey1").value("tagValue2").build(),
+                Tag.builder().key("tagKey5").value("tagValue5").build(),
+                Tag.builder().key("tagKey6").value("tagValue6").build()
         );
 
         // expected tags to remove
         final List<Tag> expectedTagsToRemove = ImmutableList.of(
-            Tag.builder().key("tagKey1").value("tagValue1").build(),
-            Tag.builder().key("tagKey2").value("tagValue2").build(),
-            Tag.builder().key("tagKey3").value("tagValue3").build()
+                Tag.builder().key("tagKey1").value("tagValue1").build(),
+                Tag.builder().key("tagKey2").value("tagValue2").build(),
+                Tag.builder().key("tagKey3").value("tagValue3").build()
         );
 
         Mockito.doThrow(ssmException).when(tagClient).addTags(expectedTagsToAdd, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
@@ -181,74 +185,80 @@ public class TagUpdaterTest {
         Mockito.when(tagUtil.shouldSoftFailTags(SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmException)).thenReturn(true);
 
         unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, SAMPLE_RESOURCE_REQUEST_TAGS,
-            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy);
+                SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
 
         verifyTagClientCalls(expectedTagsToAdd, expectedTagsToRemove);
+        Mockito.verify(logger, Mockito.times(1)).log(String.format("Soft fail adding tags to %s", SAMPLE_DOCUMENT_NAME));
+        Mockito.verify(logger, Mockito.times(1)).log(String.format("Soft fail removing tags from %s", SAMPLE_DOCUMENT_NAME));
     }
 
     @Test
     public void testUpdateTags_addTagsAPIAccessDenied_shouldNotSoftFail_verifyTagsAddedAndRemoved() {
         final Map<String, String> SAMPLE_RESOURCE_REQUEST_TAGS = ImmutableMap.of(
-            "tagKey1", "tagValue2",
-            "tagKey5", "tagValue5",
-            "tagKey6", "tagValue6"
+                "tagKey1", "tagValue2",
+                "tagKey5", "tagValue5",
+                "tagKey6", "tagValue6"
         );
 
 
         // Expected tags to add
         final List<Tag> expectedTagsToAdd = ImmutableList.of(
-            Tag.builder().key("tagKey1").value("tagValue2").build(),
-            Tag.builder().key("tagKey5").value("tagValue5").build(),
-            Tag.builder().key("tagKey6").value("tagValue6").build()
+                Tag.builder().key("tagKey1").value("tagValue2").build(),
+                Tag.builder().key("tagKey5").value("tagValue5").build(),
+                Tag.builder().key("tagKey6").value("tagValue6").build()
         );
 
         // expected tags to remove
         final List<Tag> expectedTagsToRemove = ImmutableList.of(
-            Tag.builder().key("tagKey1").value("tagValue1").build(),
-            Tag.builder().key("tagKey2").value("tagValue2").build(),
-            Tag.builder().key("tagKey3").value("tagValue3").build()
+                Tag.builder().key("tagKey1").value("tagValue1").build(),
+                Tag.builder().key("tagKey2").value("tagValue2").build(),
+                Tag.builder().key("tagKey3").value("tagValue3").build()
         );
 
         Mockito.doThrow(ssmException).when(tagClient).addTags(expectedTagsToAdd, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
         Mockito.when(tagUtil.shouldSoftFailTags(SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmException)).thenReturn(false);
 
         Assertions.assertThrows(SsmException.class, () -> unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, SAMPLE_RESOURCE_REQUEST_TAGS,
-            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy));
+                SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy, logger));
 
         Mockito.verify(tagClient, Mockito.times(1)).removeTags(expectedTagsToRemove, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
+        Mockito.verify(logger, Mockito.never()).log(String.format("Soft fail adding tags to %s", SAMPLE_DOCUMENT_NAME));
+        Mockito.verify(logger, Mockito.never()).log(String.format("Soft fail removing tags from %s", SAMPLE_DOCUMENT_NAME));
     }
 
     @Test
     public void testUpdateTags_removeTagsAPIAccessDenied_shouldNotSoftFail_verifyTagsAddedAndRemoved() {
         final Map<String, String> SAMPLE_RESOURCE_REQUEST_TAGS = ImmutableMap.of(
-            "tagKey1", "tagValue2",
-            "tagKey5", "tagValue5",
-            "tagKey6", "tagValue6"
+                "tagKey1", "tagValue2",
+                "tagKey5", "tagValue5",
+                "tagKey6", "tagValue6"
         );
 
         // Expected tags to add
         final List<Tag> expectedTagsToAdd = ImmutableList.of(
-            Tag.builder().key("tagKey1").value("tagValue2").build(),
-            Tag.builder().key("tagKey5").value("tagValue5").build(),
-            Tag.builder().key("tagKey6").value("tagValue6").build()
+                Tag.builder().key("tagKey1").value("tagValue2").build(),
+                Tag.builder().key("tagKey5").value("tagValue5").build(),
+                Tag.builder().key("tagKey6").value("tagValue6").build()
         );
 
         // expected tags to remove
         final List<Tag> expectedTagsToRemove = ImmutableList.of(
-            Tag.builder().key("tagKey1").value("tagValue1").build(),
-            Tag.builder().key("tagKey2").value("tagValue2").build(),
-            Tag.builder().key("tagKey3").value("tagValue3").build()
+                Tag.builder().key("tagKey1").value("tagValue1").build(),
+                Tag.builder().key("tagKey2").value("tagValue2").build(),
+                Tag.builder().key("tagKey3").value("tagValue3").build()
         );
 
         Mockito.doThrow(ssmException).when(tagClient).removeTags(expectedTagsToRemove, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
         Mockito.when(tagUtil.shouldSoftFailTags(SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmException)).thenReturn(false);
 
         Assertions.assertThrows(SsmException.class, () -> unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME,
-            SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, SAMPLE_RESOURCE_REQUEST_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
-            SAMPLE_MODEL_TAGS, ssmClient, proxy));
+                SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, SAMPLE_RESOURCE_REQUEST_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
+                SAMPLE_MODEL_TAGS, ssmClient, proxy, logger));
 
         Mockito.verify(tagClient, Mockito.times(1)).removeTags(expectedTagsToRemove, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
         Mockito.verify(tagClient, Mockito.never()).addTags(expectedTagsToAdd, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
+        Mockito.verify(logger, Mockito.never()).log(String.format("Soft fail adding tags to %s", SAMPLE_DOCUMENT_NAME));
+        Mockito.verify(logger, Mockito.never()).log(String.format("Soft fail removing tags from %s", SAMPLE_DOCUMENT_NAME));
     }
 
     private void verifyTagClientCalls(final List<Tag> expectedTagsToAdd, final List<Tag> expectedTagsToRemove) {

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/tags/TagUpdaterTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/tags/TagUpdaterTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.SsmException;
 import software.amazon.awssdk.services.ssm.model.Tag;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 
@@ -37,6 +39,21 @@ public class TagUpdaterTest {
         Tag.builder().key("tagKey3").value("tagValue3").build()
     );
 
+    private static final Map<String, String> SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS = ImmutableMap.of(
+        "tagKey1", "tagValue1",
+        "tagKey2", "tagValue2",
+        "tagKey3", "tagValue3"
+    );
+
+    private static final List<com.amazonaws.ssm.document.Tag> SAMPLE_PREVIOUS_MODEL_TAGS = ImmutableList.of(
+        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey1").value("tagModelValue1").build(),
+        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey2").value("tagModelValue2").build()
+    );
+    private static final List<com.amazonaws.ssm.document.Tag> SAMPLE_MODEL_TAGS = ImmutableList.of(
+        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey3").value("tagModelValue3").build(),
+        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey4").value("tagModelValue4").build()
+    );
+
     @Mock
     private SsmClient ssmClient;
 
@@ -46,34 +63,33 @@ public class TagUpdaterTest {
     @Mock
     private TagClient tagClient;
 
+    @Mock
+    private TagUtil tagUtil;
+
+    @Mock
+    private SsmException ssmException;
+
     private TagUpdater unitUnderTest;
 
     @BeforeEach
     private void setup() {
-        unitUnderTest = new TagUpdater(tagClient);
-    }
-
-    @Test
-    public void testUpdateTags_resourceTagsIsNull_verifyCalls() {
-        unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_RESOURCE_REQUEST_TAGS, ssmClient, proxy);
-
-        Mockito.verifyZeroInteractions(proxy);
+        unitUnderTest = new TagUpdater(tagClient, tagUtil);
     }
 
     @Test
     public void testUpdateTags_existingTagsIsEmpty_verifyCalls() {
-        Mockito.when(tagClient.listTags(SAMPLE_DOCUMENT_NAME, ssmClient, proxy)).thenReturn(ImmutableList.of());
 
-        unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_RESOURCE_REQUEST_TAGS, ssmClient, proxy);
+        unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, ImmutableMap.of(), SAMPLE_RESOURCE_REQUEST_TAGS,
+            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy);
 
         verifyTagClientCalls(SAMPLE_RESOURCE_REQUEST_TAGS_SSM_FORMAT, ImmutableList.of());
     }
 
     @Test
     public void testUpdateTags_requestedTagsIsEmpty_verifyCalls() {
-        Mockito.when(tagClient.listTags(SAMPLE_DOCUMENT_NAME, ssmClient, proxy)).thenReturn(SAMPLE_EXISTING_TAGS);
 
-        unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, ImmutableMap.of(), ssmClient, proxy);
+        unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, ImmutableMap.of(),
+            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy);
 
         // Expected tags to add
         final List<Tag> expectedTagsToAdd = ImmutableList.of(
@@ -91,7 +107,6 @@ public class TagUpdaterTest {
 
     @Test
     public void testUpdateTags_existingTagsIsNotEmpty_verifyTagsAddedAndRemoved() {
-        Mockito.when(tagClient.listTags(SAMPLE_DOCUMENT_NAME, ssmClient, proxy)).thenReturn(SAMPLE_EXISTING_TAGS);
 
         // Expected tags to add
         final List<Tag> expectedTagsToAdd = ImmutableList.of(
@@ -105,7 +120,8 @@ public class TagUpdaterTest {
             Tag.builder().key("tagKey3").value("tagValue3").build()
         );
 
-        unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_RESOURCE_REQUEST_TAGS, ssmClient, proxy);
+        unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, SAMPLE_RESOURCE_REQUEST_TAGS,
+            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy);
 
         verifyTagClientCalls(expectedTagsToAdd, expectedTagsToRemove);
    }
@@ -117,8 +133,6 @@ public class TagUpdaterTest {
             "tagKey5", "tagValue5",
             "tagKey6", "tagValue6"
         );
-
-        Mockito.when(tagClient.listTags(SAMPLE_DOCUMENT_NAME, ssmClient, proxy)).thenReturn(SAMPLE_EXISTING_TAGS);
 
         // Expected tags to add
         final List<Tag> expectedTagsToAdd = ImmutableList.of(
@@ -134,9 +148,107 @@ public class TagUpdaterTest {
             Tag.builder().key("tagKey3").value("tagValue3").build()
         );
 
-        unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_RESOURCE_REQUEST_TAGS, ssmClient, proxy);
+        unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, SAMPLE_RESOURCE_REQUEST_TAGS,
+            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy);
 
         verifyTagClientCalls(expectedTagsToAdd, expectedTagsToRemove);
+    }
+
+    @Test
+    public void testUpdateTags_addTagsAPIAccessDenied_shouldSoftFail_verifyTagsAddedAndRemoved() {
+        final Map<String, String> SAMPLE_RESOURCE_REQUEST_TAGS = ImmutableMap.of(
+            "tagKey1", "tagValue2",
+            "tagKey5", "tagValue5",
+            "tagKey6", "tagValue6"
+        );
+
+        // Expected tags to add
+        final List<Tag> expectedTagsToAdd = ImmutableList.of(
+            Tag.builder().key("tagKey1").value("tagValue2").build(),
+            Tag.builder().key("tagKey5").value("tagValue5").build(),
+            Tag.builder().key("tagKey6").value("tagValue6").build()
+        );
+
+        // expected tags to remove
+        final List<Tag> expectedTagsToRemove = ImmutableList.of(
+            Tag.builder().key("tagKey1").value("tagValue1").build(),
+            Tag.builder().key("tagKey2").value("tagValue2").build(),
+            Tag.builder().key("tagKey3").value("tagValue3").build()
+        );
+
+        Mockito.doThrow(ssmException).when(tagClient).addTags(expectedTagsToAdd, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
+        Mockito.doThrow(ssmException).when(tagClient).removeTags(expectedTagsToRemove, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
+        Mockito.when(tagUtil.shouldSoftFailTags(SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmException)).thenReturn(true);
+
+        unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, SAMPLE_RESOURCE_REQUEST_TAGS,
+            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy);
+
+        verifyTagClientCalls(expectedTagsToAdd, expectedTagsToRemove);
+    }
+
+    @Test
+    public void testUpdateTags_addTagsAPIAccessDenied_shouldNotSoftFail_verifyTagsAddedAndRemoved() {
+        final Map<String, String> SAMPLE_RESOURCE_REQUEST_TAGS = ImmutableMap.of(
+            "tagKey1", "tagValue2",
+            "tagKey5", "tagValue5",
+            "tagKey6", "tagValue6"
+        );
+
+
+        // Expected tags to add
+        final List<Tag> expectedTagsToAdd = ImmutableList.of(
+            Tag.builder().key("tagKey1").value("tagValue2").build(),
+            Tag.builder().key("tagKey5").value("tagValue5").build(),
+            Tag.builder().key("tagKey6").value("tagValue6").build()
+        );
+
+        // expected tags to remove
+        final List<Tag> expectedTagsToRemove = ImmutableList.of(
+            Tag.builder().key("tagKey1").value("tagValue1").build(),
+            Tag.builder().key("tagKey2").value("tagValue2").build(),
+            Tag.builder().key("tagKey3").value("tagValue3").build()
+        );
+
+        Mockito.doThrow(ssmException).when(tagClient).addTags(expectedTagsToAdd, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
+        Mockito.when(tagUtil.shouldSoftFailTags(SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmException)).thenReturn(false);
+
+        Assertions.assertThrows(SsmException.class, () -> unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, SAMPLE_RESOURCE_REQUEST_TAGS,
+            SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy));
+
+        Mockito.verify(tagClient, Mockito.times(1)).removeTags(expectedTagsToRemove, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
+    }
+
+    @Test
+    public void testUpdateTags_removeTagsAPIAccessDenied_shouldNotSoftFail_verifyTagsAddedAndRemoved() {
+        final Map<String, String> SAMPLE_RESOURCE_REQUEST_TAGS = ImmutableMap.of(
+            "tagKey1", "tagValue2",
+            "tagKey5", "tagValue5",
+            "tagKey6", "tagValue6"
+        );
+
+        // Expected tags to add
+        final List<Tag> expectedTagsToAdd = ImmutableList.of(
+            Tag.builder().key("tagKey1").value("tagValue2").build(),
+            Tag.builder().key("tagKey5").value("tagValue5").build(),
+            Tag.builder().key("tagKey6").value("tagValue6").build()
+        );
+
+        // expected tags to remove
+        final List<Tag> expectedTagsToRemove = ImmutableList.of(
+            Tag.builder().key("tagKey1").value("tagValue1").build(),
+            Tag.builder().key("tagKey2").value("tagValue2").build(),
+            Tag.builder().key("tagKey3").value("tagValue3").build()
+        );
+
+        Mockito.doThrow(ssmException).when(tagClient).removeTags(expectedTagsToRemove, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
+        Mockito.when(tagUtil.shouldSoftFailTags(SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmException)).thenReturn(false);
+
+        Assertions.assertThrows(SsmException.class, () -> unitUnderTest.updateTags(SAMPLE_DOCUMENT_NAME,
+            SAMPLE_EXISTING_RESOURCE_REQUEST_TAGS, SAMPLE_RESOURCE_REQUEST_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
+            SAMPLE_MODEL_TAGS, ssmClient, proxy));
+
+        Mockito.verify(tagClient, Mockito.times(1)).removeTags(expectedTagsToRemove, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
+        Mockito.verify(tagClient, Mockito.never()).addTags(expectedTagsToAdd, SAMPLE_DOCUMENT_NAME, ssmClient, proxy);
     }
 
     private void verifyTagClientCalls(final List<Tag> expectedTagsToAdd, final List<Tag> expectedTagsToRemove) {

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/tags/TagUtilTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/tags/TagUtilTest.java
@@ -1,0 +1,86 @@
+package com.amazonaws.ssm.document.tags;
+
+import com.amazonaws.ssm.document.Tag;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.ssm.model.SsmException;
+
+@ExtendWith(MockitoExtension.class)
+public class TagUtilTest {
+
+    private static final List<Tag> SAMPLE_PREVIOUS_MODEL_TAGS = ImmutableList.of(
+        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey1").value("tagModelValue1").build(),
+        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey2").value("tagModelValue2").build()
+    );
+    private static final List<com.amazonaws.ssm.document.Tag> SAMPLE_MODEL_TAGS = ImmutableList.of(
+        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey3").value("tagModelValue3").build(),
+        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey4").value("tagModelValue4").build()
+    );
+    private static final AwsErrorDetails ACCESS_DENIED_ERROR_DETAILS = AwsErrorDetails.builder()
+        .errorCode("AccessDeniedException")
+        .build();
+
+    @Mock
+    private SsmException ssmException;
+
+    private TagUtil unitUnderTest;
+
+    @BeforeEach
+    private void setup() {
+        unitUnderTest = new TagUtil();
+    }
+
+    @Test
+    public void testShouldSoftFail_NotAccessDeniedException_isFalse() {
+        final AwsErrorDetails errorDetails = AwsErrorDetails.builder()
+            .errorCode("AccessDeniedException")
+            .build();
+
+        Mockito.when(ssmException.awsErrorDetails()).thenReturn(errorDetails);
+
+        Assertions.assertFalse(unitUnderTest.shouldSoftFailTags(SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmException));
+    }
+
+    @Test
+    public void testShouldSoftFail_AccessDeniedException_PreviousModelTagsNonNull_currentModelTagsNull_isFalse() {
+        Mockito.when(ssmException.awsErrorDetails()).thenReturn(ACCESS_DENIED_ERROR_DETAILS);
+
+        Assertions.assertFalse(unitUnderTest.shouldSoftFailTags(SAMPLE_PREVIOUS_MODEL_TAGS, null, ssmException));
+    }
+
+    @Test
+    public void testShouldSoftFail_AccessDeniedException_PreviousModelTagsNull_CurrentModelTagsNonNull_isFalse() {
+        Mockito.when(ssmException.awsErrorDetails()).thenReturn(ACCESS_DENIED_ERROR_DETAILS);
+
+        Assertions.assertFalse(unitUnderTest.shouldSoftFailTags(null, SAMPLE_MODEL_TAGS, ssmException));
+    }
+
+    @Test
+    public void testShouldSoftFail_AccessDeniedException_PreviousModelTagsNonNull_CurrentModelTagsNonNull_isFalse() {
+        Mockito.when(ssmException.awsErrorDetails()).thenReturn(ACCESS_DENIED_ERROR_DETAILS);
+
+        Assertions.assertFalse(unitUnderTest.shouldSoftFailTags(SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmException));
+    }
+
+    @Test
+    public void testShouldSoftFail_AccessDeniedException_PreviousModelTagsNull_CurrentModelTagsNull_isTrue() {
+        Mockito.when(ssmException.awsErrorDetails()).thenReturn(ACCESS_DENIED_ERROR_DETAILS);
+
+        Assertions.assertTrue(unitUnderTest.shouldSoftFailTags(null, null, ssmException));
+    }
+
+    @Test
+    public void testShouldSoftFail_AccessDeniedException_PreviousModelTagsEmpty_CurrentModelTagsEmpty_isTrue() {
+        Mockito.when(ssmException.awsErrorDetails()).thenReturn(ACCESS_DENIED_ERROR_DETAILS);
+
+        Assertions.assertTrue(unitUnderTest.shouldSoftFailTags(ImmutableList.of(), ImmutableList.of(), ssmException));
+    }
+}

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/tags/TagUtilTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/tags/TagUtilTest.java
@@ -17,16 +17,16 @@ import software.amazon.awssdk.services.ssm.model.SsmException;
 public class TagUtilTest {
 
     private static final List<Tag> SAMPLE_PREVIOUS_MODEL_TAGS = ImmutableList.of(
-        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey1").value("tagModelValue1").build(),
-        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey2").value("tagModelValue2").build()
+            com.amazonaws.ssm.document.Tag.builder().key("tagModelKey1").value("tagModelValue1").build(),
+            com.amazonaws.ssm.document.Tag.builder().key("tagModelKey2").value("tagModelValue2").build()
     );
     private static final List<com.amazonaws.ssm.document.Tag> SAMPLE_MODEL_TAGS = ImmutableList.of(
-        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey3").value("tagModelValue3").build(),
-        com.amazonaws.ssm.document.Tag.builder().key("tagModelKey4").value("tagModelValue4").build()
+            com.amazonaws.ssm.document.Tag.builder().key("tagModelKey3").value("tagModelValue3").build(),
+            com.amazonaws.ssm.document.Tag.builder().key("tagModelKey4").value("tagModelValue4").build()
     );
     private static final AwsErrorDetails ACCESS_DENIED_ERROR_DETAILS = AwsErrorDetails.builder()
-        .errorCode("AccessDeniedException")
-        .build();
+            .errorCode("AccessDeniedException")
+            .build();
 
     @Mock
     private SsmException ssmException;
@@ -35,14 +35,14 @@ public class TagUtilTest {
 
     @BeforeEach
     private void setup() {
-        unitUnderTest = new TagUtil();
+        unitUnderTest = TagUtil.getInstance();
     }
 
     @Test
     public void testShouldSoftFail_NotAccessDeniedException_isFalse() {
         final AwsErrorDetails errorDetails = AwsErrorDetails.builder()
-            .errorCode("AccessDeniedException")
-            .build();
+                .errorCode("AccessDeniedException")
+                .build();
 
         Mockito.when(ssmException.awsErrorDetails()).thenReturn(errorDetails);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
During resource create or update, customer may not have permissions to Tagging APIs, but cloudformation has a concept of stack level tags. When tags are applied at stack level, it doesn't necessarily mean that customer is intending to apply tags to this particular resource. In this scenario, we do a best effort to apply the stack level tags to resource and not fail if customer does not have permissions. But if customer provided resource level tags, we do a hard fail if customer does not have permissions. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
