### PR TITLE
Support YAML ObjectMapper when DocumentFormat YAML specified

### DIFF
--- a/aws-ssm-document/pom.xml
+++ b/aws-ssm-document/pom.xml
@@ -46,6 +46,12 @@
             <version>1.18.4</version>
             <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.10.1</version>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
SSM Documents support Json and Yaml format. The current behavior when customer create SSM document by CloudFormation, no matter what [DocumentFormat](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-document.html#cfn-ssm-document-documentformat) specified in CloudFormation it will always convert into a JSON format string. 

Scope of this change:
1. Use YAML ObjectMapper when customer specified YAML DocumentFormat
2. Using JSON ObjectMapper if no DocumentFormat specified
3. Convert into Pretty JSON string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
