### PR TITLE
add support for updating AWS::SSM::Document with new versions

### DIFF
--- a/aws-ssm-document/aws-ssm-document.json
+++ b/aws-ssm-document/aws-ssm-document.json
@@ -155,6 +155,15 @@
             },
             "minItems": 1,
             "insertionOrder": false
+        },
+        "UpdateMethod": {
+            "description": "Update method - when set to 'Replace', the update will replace the existing document; when set to 'NewVersion', the update will create a new version.",
+            "type": "string",
+            "enum": [
+                "Replace",
+                "NewVersion"
+            ],
+            "default": "Replace"
         }
     },
     "additionalProperties": false,
@@ -162,14 +171,8 @@
         "Content"
     ],
     "createOnlyProperties": [
-        "/properties/Content",
-        "/properties/Attachments",
         "/properties/Name",
-        "/properties/VersionName",
-        "/properties/DocumentType",
-        "/properties/DocumentFormat",
-        "/properties/TargetType",
-        "/properties/Requires"
+        "/properties/DocumentType"
     ],
     "primaryIdentifier": [
         "/properties/Name"
@@ -194,12 +197,19 @@
                 "ssm:AddTagsToResource",
                 "ssm:RemoveTagsFromResource",
                 "ssm:ListTagsForResource",
-                "iam:PassRole"
+                "iam:PassRole",
+                "ssm:UpdateDocumentDefaultVersion",
+                "ssm:DescribeDocument"
             ]
         },
         "delete": {
             "permissions": [
                 "ssm:DeleteDocument"
+            ]
+        },
+        "list": {
+            "permissions": [
+                "ssm:ListDocuments"
             ]
         }
     }

--- a/aws-ssm-document/resource-role.yaml
+++ b/aws-ssm-document/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-SSM-Document/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy
@@ -28,10 +35,13 @@ Resources:
                 - "ssm:AddTagsToResource"
                 - "ssm:CreateDocument"
                 - "ssm:DeleteDocument"
+                - "ssm:DescribeDocument"
                 - "ssm:GetDocument"
+                - "ssm:ListDocuments"
                 - "ssm:ListTagsForResource"
                 - "ssm:RemoveTagsFromResource"
                 - "ssm:UpdateDocument"
+                - "ssm:UpdateDocumentDefaultVersion"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentExceptionTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentExceptionTranslator.java
@@ -5,11 +5,14 @@ import software.amazon.awssdk.services.ssm.model.AutomationDefinitionVersionNotF
 import software.amazon.awssdk.services.ssm.model.DocumentAlreadyExistsException;
 import software.amazon.awssdk.services.ssm.model.DocumentLimitExceededException;
 import software.amazon.awssdk.services.ssm.model.DocumentVersionLimitExceededException;
+import software.amazon.awssdk.services.ssm.model.DuplicateDocumentContentException;
+import software.amazon.awssdk.services.ssm.model.DuplicateDocumentVersionNameException;
 import software.amazon.awssdk.services.ssm.model.InternalServerErrorException;
 import software.amazon.awssdk.services.ssm.model.InvalidDocumentContentException;
 import software.amazon.awssdk.services.ssm.model.InvalidDocumentException;
 import software.amazon.awssdk.services.ssm.model.InvalidDocumentSchemaVersionException;
 import software.amazon.awssdk.services.ssm.model.InvalidDocumentVersionException;
+import software.amazon.awssdk.services.ssm.model.InvalidNextTokenException;
 import software.amazon.awssdk.services.ssm.model.InvalidResourceIdException;
 import software.amazon.awssdk.services.ssm.model.MaxDocumentSizeExceededException;
 import software.amazon.awssdk.services.ssm.model.SsmException;
@@ -25,6 +28,8 @@ import software.amazon.cloudformation.proxy.Logger;
 
 import lombok.NonNull;
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 
 class DocumentExceptionTranslator {
 
@@ -45,7 +50,7 @@ class DocumentExceptionTranslator {
         return INSTANCE;
     }
 
-    RuntimeException getCfnException(@NonNull final SsmException e, @NonNull String documentName, @NonNull String operationName,
+    RuntimeException getCfnException(@NonNull final SsmException e, String documentName, @NonNull String operationName,
                                      @NonNull final Logger logger) {
 
         logger.log(String.format(EXCEPTION_METRIC_FILTER_PATTERN, operationName, e.getClass()));
@@ -60,7 +65,9 @@ class DocumentExceptionTranslator {
 
         } else if (e instanceof MaxDocumentSizeExceededException || e instanceof InvalidDocumentContentException
                 || e instanceof InvalidDocumentVersionException || e instanceof InvalidDocumentSchemaVersionException
-                || e instanceof AutomationDefinitionNotFoundException || e instanceof AutomationDefinitionVersionNotFoundException) {
+                || e instanceof AutomationDefinitionNotFoundException || e instanceof AutomationDefinitionVersionNotFoundException
+                || e instanceof DuplicateDocumentContentException || e instanceof DuplicateDocumentVersionNameException
+                || e instanceof InvalidNextTokenException) {
 
             return new CfnInvalidRequestException(e.getMessage(), e);
 

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentModelTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentModelTranslator.java
@@ -22,6 +22,7 @@ import software.amazon.awssdk.services.ssm.model.Tag;
 
 import lombok.NonNull;
 import software.amazon.awssdk.services.ssm.model.UpdateDocumentRequest;
+import software.amazon.awssdk.services.ssm.model.UpdateDocumentDefaultVersionRequest;
 import software.amazon.cloudformation.resource.IdentifierUtils;
 
 import javax.annotation.Nullable;
@@ -114,6 +115,13 @@ class DocumentModelTranslator {
                 .documentFormat(model.getDocumentFormat())
                 .targetType(model.getTargetType())
                 .attachments(translateAttachments(model.getAttachments()))
+                .build();
+    }
+
+    UpdateDocumentDefaultVersionRequest generateUpdateDocumentDefaultVersionRequest(@NonNull final String name, @NonNull final String latestVersion) {
+        return UpdateDocumentDefaultVersionRequest.builder()
+                .name(name)
+                .documentVersion(latestVersion)
                 .build();
     }
 

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
@@ -59,6 +59,8 @@ class DocumentResponseModelTranslator {
                 .resourceModel(model)
                 .status(state)
                 .statusInformation(response.document().statusInformation())
+                .latestVersion(response.document().latestVersion())
+                .defaultVersion(response.document().defaultVersion())
                 .build();
     }
 

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/ResourceInformation.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/ResourceInformation.java
@@ -18,4 +18,10 @@ class ResourceInformation {
 
     @Nullable
     private final String statusInformation;
+
+    @Nullable
+    private final String latestVersion;
+
+    @Nullable
+    private final String defaultVersion;
 }

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/UpdateHandler.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/UpdateHandler.java
@@ -6,7 +6,16 @@ import com.google.common.annotations.VisibleForTesting;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.DescribeDocumentRequest;
+import software.amazon.awssdk.services.ssm.model.DescribeDocumentResponse;
+import software.amazon.awssdk.services.ssm.model.DuplicateDocumentContentException;
+import software.amazon.awssdk.services.ssm.model.DuplicateDocumentVersionNameException;
 import software.amazon.awssdk.services.ssm.model.SsmException;
+import software.amazon.awssdk.services.ssm.model.UpdateDocumentRequest;
+import software.amazon.awssdk.services.ssm.model.UpdateDocumentResponse;
+import software.amazon.awssdk.services.ssm.model.UpdateDocumentDefaultVersionRequest;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -16,6 +25,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Update AWS::SSM::Document resource.
@@ -33,6 +43,8 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
     private static final int NUMBER_OF_DOCUMENT_UPDATE_POLL_RETRIES = 10 * 60 / CALLBACK_DELAY_SECONDS;
 
     private static final String OPERATION_NAME = "AWS::SSM::UpdateDocument";
+
+    private static final String NEW_VERSION = "NewVersion";
 
     @NonNull
     private final DocumentModelTranslator documentModelTranslator;
@@ -70,47 +82,184 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         final ResourceModel model = request.getDesiredResourceState();
         final ResourceModel previousModel = request.getPreviousResourceState();
 
-        safeLogger.safeLogDocumentInformation(model, callbackContext, request.getAwsAccountId(), request.getSystemTags(), logger);
+        boolean isTrueUpdate = model.getUpdateMethod() != null && model.getUpdateMethod().equalsIgnoreCase(NEW_VERSION);
 
-        // Only Tags are handled in Update Handler. Other properties of the Document resource are CreateOnly.
-        // Verify no CreateOnly properties are modified
-        if(isCreateOnlyModified(model, previousModel)) {
-            return ProgressEvent.failed(
-                    model,
-                    context,
-                    HandlerErrorCode.NotUpdatable, "Create-Only Property cannot be updated");
+        if (isTrueUpdate && model.getName() == null) {
+            model.setName(previousModel.getName()); // use the previously used documentName for true update
         }
 
-        try {
-            logger.log("update tags request for document name: " + model.getName());
-            tagUpdater.updateTags(model.getName(), request.getPreviousResourceTags(), request.getDesiredResourceTags(),
-                    previousModel.getTags(), model.getTags(),
-                    ssmClient, proxy, logger);
+        safeLogger.safeLogDocumentInformation(model, callbackContext, request.getAwsAccountId(), request.getSystemTags(), logger);
 
-            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+        if (context.getEventStarted() != null) {
+            return updateProgress(model, context, ssmClient, proxy, logger);
+        }
+
+        if(isCreateOnlyModified(model, previousModel, isTrueUpdate)) {
+            if (isTrueUpdate) {
+                // Name and DocumentType cannot be updated with True Update
+                throw new CfnInvalidRequestException("Create-Only Property cannot be updated with true update.");
+            } else {
+                throw new CfnNotUpdatableException(new Exception("Create-Only Property cannot be updated."));
+            }
+        }
+
+        if (!Objects.equals(previousModel.getTags(), model.getTags())) {
+            try {
+                logger.log("update tags request for document name: " + model.getName());
+                tagUpdater.updateTags(model.getName(), request.getPreviousResourceTags(), request.getDesiredResourceTags(),
+                        previousModel.getTags(), model.getTags(),
+                        ssmClient, proxy, logger);
+            } catch (final SsmException e) {
+                throw exceptionTranslator.getCfnException(e, model.getName(), OPERATION_NAME, logger);
+            }
+        }
+
+        if (isTrueUpdate && isUpdatableModified(model, previousModel)) { // remove
+            final UpdateDocumentRequest updateDocumentRequest;
+            try {
+                updateDocumentRequest = documentModelTranslator.generateUpdateDocumentRequest(model);
+            } catch (final InvalidDocumentContentException e) {
+                throw new CfnInvalidRequestException(e.getMessage(), e);
+            }
+            
+            try {
+                final UpdateDocumentResponse response = proxy.injectCredentialsAndInvokeV2(updateDocumentRequest, ssmClient::updateDocument);
+                setInProgressContext(context);
+
+                return getInProgressEvent(model, context, UPDATING_MESSAGE);
+            } catch (final SsmException e) {
+                throw exceptionTranslator.getCfnException(e, model.getName(), OPERATION_NAME, logger);
+            }
+        }
+
+        return ProgressEvent.<ResourceModel, CallbackContext>builder()
                     .resourceModel(model)
                     .status(OperationStatus.SUCCESS)
                     .callbackContext(context)
                     .callbackDelaySeconds(0)
                     .build();
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> updateProgress(final ResourceModel model, final CallbackContext context,
+                                                                         final SsmClient ssmClient,
+                                                                         final AmazonWebServicesClientProxy proxy,
+                                                                         final Logger logger) {
+        final GetProgressResponse progressResponse;
+
+        try {
+            progressResponse = stabilizationProgressRetriever.getEventProgress(model, context, ssmClient, proxy, logger);
         } catch (final SsmException e) {
             throw exceptionTranslator.getCfnException(e, model.getName(), OPERATION_NAME, logger);
         }
+
+        final ResourceInformation resourceInformation = progressResponse.getResourceInformation();
+
+        final OperationStatus operationStatus = getOperationStatus(resourceInformation.getStatus());
+
+        if (operationStatus == OperationStatus.SUCCESS) {
+            // Update document default version after updateDocument completes
+            String latestVersion = resourceInformation.getLatestVersion();
+            String defaultVersion = resourceInformation.getDefaultVersion();
+
+            if (latestVersion == null || defaultVersion == null) {
+                final DescribeDocumentRequest describeDocumentRequest = 
+                    documentModelTranslator.generateDescribeDocumentRequest(model);
+                try {
+                    final DescribeDocumentResponse describeResponse = 
+                        proxy.injectCredentialsAndInvokeV2(describeDocumentRequest, ssmClient::describeDocument);
+                    latestVersion = describeResponse.document().latestVersion();
+                    defaultVersion = describeResponse.document().defaultVersion();
+                } catch(SsmException e) {
+                    throw exceptionTranslator.getCfnException(e, model.getName(), OPERATION_NAME, logger);
+                }
+            }
+
+            if (!latestVersion.equalsIgnoreCase(defaultVersion)) {
+                final UpdateDocumentDefaultVersionRequest request = 
+                    documentModelTranslator.generateUpdateDocumentDefaultVersionRequest(model.getName(), latestVersion);
+
+                try {
+                    proxy.injectCredentialsAndInvokeV2(request, ssmClient::updateDocumentDefaultVersion);
+                } catch (SsmException e) {
+                    throw exceptionTranslator.getCfnException(e, model.getName(), OPERATION_NAME, logger);
+                }
+            }            
+        }
+
+        return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModel(model)
+                .status(operationStatus)
+                .message(resourceInformation.getStatusInformation())
+                .callbackContext(progressResponse.getCallbackContext())
+                .callbackDelaySeconds(setCallbackDelay(operationStatus))
+                .build();
     }
 
-    private boolean isCreateOnlyModified(final ResourceModel model, final ResourceModel previousModel) {
+    private int setCallbackDelay(final OperationStatus operationStatus) {
+        return operationStatus == OperationStatus.SUCCESS ? 0 : CALLBACK_DELAY_SECONDS;
+    }
+
+    private OperationStatus getOperationStatus(@NonNull final ResourceStatus status) {
+        switch (status) {
+            case ACTIVE:
+                return OperationStatus.SUCCESS;
+            case UPDATING:
+                return OperationStatus.IN_PROGRESS;
+            default:
+                return OperationStatus.FAILED;
+        }
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> getInProgressEvent(final ResourceModel model,
+                                                                             final CallbackContext context,
+                                                                             final String message) {
+        return ProgressEvent.<ResourceModel, CallbackContext>builder()
+            .resourceModel(model)
+            .status(OperationStatus.IN_PROGRESS)
+            .message(message)
+            .callbackContext(context)
+            .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
+            .build();
+    }
+
+    private void setInProgressContext(CallbackContext context) {
+        context.setEventStarted(true);
+        context.setStabilizationRetriesRemaining(NUMBER_OF_DOCUMENT_UPDATE_POLL_RETRIES);
+    }
+
+    private boolean isCreateOnlyModified(final ResourceModel model, final ResourceModel previousModel, boolean isTrueUpdate) {
         final ResourceModel comparator = ResourceModel.builder()
                 //CreatOnly Properties
                 .name(model.getName())
+                .documentType(model.getDocumentType())
+                //Modifiable Properties
+                .tags(previousModel.getTags())
+                .updateMethod(previousModel.getUpdateMethod())
+                //Properties that depend on UpdateMethod
+                .content(isTrueUpdate ? previousModel.getContent() : model.getContent())
+                .attachments(isTrueUpdate ? previousModel.getAttachments() : model.getAttachments())
+                .versionName(isTrueUpdate ? previousModel.getVersionName() : model.getVersionName())
+                .documentFormat(isTrueUpdate ? previousModel.getDocumentFormat() : model.getDocumentFormat())
+                .targetType(isTrueUpdate ? previousModel.getTargetType() : model.getTargetType())
+                .requires(isTrueUpdate ? previousModel.getRequires() : model.getRequires())
+                .build();
+        return !comparator.equals(previousModel);
+    }
+
+    private boolean isUpdatableModified(final ResourceModel model, final ResourceModel previousModel) {
+        final ResourceModel comparator = ResourceModel.builder()
+                .name(previousModel.getName())
+                .documentType(previousModel.getDocumentType())
+                .tags(previousModel.getTags())
+                .updateMethod(previousModel.getUpdateMethod())
+                //Requires is not updatable through SDK
+                .requires(previousModel.getRequires())
+                //Properties allowed to be updated using UpdateDocument
                 .content(model.getContent())
                 .attachments(model.getAttachments())
                 .versionName(model.getVersionName())
-                .documentType(model.getDocumentType())
                 .documentFormat(model.getDocumentFormat())
                 .targetType(model.getTargetType())
-                .requires(model.getRequires())
-                //Modifiable Properties
-                .tags(previousModel.getTags())
                 .build();
         return !comparator.equals(previousModel);
     }

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentModelTranslatorTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentModelTranslatorTest.java
@@ -48,6 +48,7 @@ public class DocumentModelTranslatorTest {
     private static final String SAMPLE_DOCUMENT_TYPE = "type";
     private static final String LATEST_DOCUMENT_VERSION = "$LATEST";
     private static final String SAMPLE_TARGET_TYPE = "targetType";
+    private static final Integer MAX_RESULTS = 50;
     private static final List<Tag> SAMPLE_RESOURCE_MODEL_TAGS = ImmutableList.of(
             Tag.builder().key("tagKey1").value("tagValue1").build(),
             Tag.builder().key("tagKey2").value("tagValue2").build()

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/UpdateHandlerTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/UpdateHandlerTest.java
@@ -6,9 +6,19 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
 import org.mockito.Mockito;
 import software.amazon.awssdk.services.ssm.SsmClient;
+import software.amazon.awssdk.services.ssm.model.DescribeDocumentRequest;
+import software.amazon.awssdk.services.ssm.model.DescribeDocumentResponse;
+import software.amazon.awssdk.services.ssm.model.DocumentDescription;
+import software.amazon.awssdk.services.ssm.model.DocumentStatus;
+import software.amazon.awssdk.services.ssm.model.DuplicateDocumentContentException;
+import software.amazon.awssdk.services.ssm.model.DuplicateDocumentVersionNameException;
 import software.amazon.awssdk.services.ssm.model.SsmException;
+import software.amazon.awssdk.services.ssm.model.UpdateDocumentDefaultVersionRequest;
 import software.amazon.awssdk.services.ssm.model.UpdateDocumentRequest;
+import software.amazon.awssdk.services.ssm.model.UpdateDocumentResponse;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -105,6 +115,8 @@ public class UpdateHandlerTest {
     private static final ResourceStatus RESOURCE_MODEL_FAILED_STATE = ResourceStatus.FAILED;
     private static final String SAMPLE_STATUS_INFO = "resource status info";
     private static final String OPERATION_NAME = "AWS::SSM::UpdateDocument";
+    private static final String NEW_VERSION = "NewVersion";
+    private static final String IN_PROGRESS_MESSAGE = "Updating";
 
     @Mock
     private AmazonWebServicesClientProxy proxy;
@@ -140,11 +152,13 @@ public class UpdateHandlerTest {
 
     @BeforeEach
     public void setup() {
+        documentModelTranslator = DocumentModelTranslator.getInstance();
         unitUnderTest = new UpdateHandler(documentModelTranslator, progressUpdater, tagUpdater, exceptionTranslator, ssmClient, safeLogger);
     }
 
+    // Test Update for Replacement
     @Test
-    public void testHandleRequest_DocumentUpdateTagsSuccess_VerifyResponse() {
+    public void testHandleRequest_withReplacement_DocumentUpdateTagsSuccess_VerifyResponse() {
 
         final ResourceModel expectedModel = ResourceModel.builder().name(SAMPLE_DOCUMENT_NAME).content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
                 .tags(SAMPLE_MODEL_TAGS)
@@ -168,7 +182,7 @@ public class UpdateHandlerTest {
     }
 
     @Test
-    public void testHandleRequest_DocumentUpdateTagsThrowsException_VerifyResponse() {
+    public void testHandleRequest_withReplacement_DocumentUpdateTagsThrowsException_VerifyResponse() {
         doThrow(ssmException).when(tagUpdater).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS,
                 SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
 
@@ -179,24 +193,447 @@ public class UpdateHandlerTest {
     }
 
     @Test
-    public void testHandleRequest_DocumentUpdateCreateOnlyPropertyFails_VerifyResponse() {
+    public void testHandleRequest_withReplacement_DocumentUpdateContentNotUpdatableException_VerifyException() {
         final ResourceModel expectedModel = ResourceModel.builder().name(SAMPLE_DOCUMENT_NAME).content(SAMPLE_DOCUMENT_CONTENT)
                 .tags(SAMPLE_MODEL_TAGS)
                 .build();
 
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(SAMPLE_PREVIOUS_RESOURCE_MODEL, expectedModel);
+        Assertions.assertThrows(CfnNotUpdatableException.class, () -> unitUnderTest.handleRequest(proxy, request, null, logger));
+
+        Mockito.verify(tagUpdater, never()).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS, SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
+                SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
+        verify(safeLogger).safeLogDocumentInformation(expectedModel, null, SAMPLE_ACCOUNT_ID, SAMPLE_SYSTEM_TAGS, logger);
+    }
+
+    @Test
+    public void testHandleRequest_withReplacement_DocumentUpdateNameNotUpdatableException_VerifyException() {
+        final ResourceModel expectedModel = ResourceModel.builder().name("NewName").content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .tags(SAMPLE_MODEL_TAGS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(SAMPLE_PREVIOUS_RESOURCE_MODEL, expectedModel);
+        Assertions.assertThrows(CfnNotUpdatableException.class, () -> unitUnderTest.handleRequest(proxy, request, null, logger));
+
+        Mockito.verify(tagUpdater, never()).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS, SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
+                SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
+        verify(safeLogger).safeLogDocumentInformation(expectedModel, null, SAMPLE_ACCOUNT_ID, SAMPLE_SYSTEM_TAGS, logger);
+    }
+
+    @Test
+    public void testHandleRequest_withReplacement_DocumentUpdateDocumentTypeNotUpdatableException_VerifyException() {
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .documentType("Automation")
+                .tags(SAMPLE_MODEL_TAGS)
+                .build();
+        final ResourceModel previousModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .documentType("Command")
+                .tags(SAMPLE_PREVIOUS_MODEL_TAGS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(previousModel, expectedModel);
+        Assertions.assertThrows(CfnNotUpdatableException.class, () -> unitUnderTest.handleRequest(proxy, request, null, logger));
+
+        Mockito.verify(tagUpdater, never()).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS, SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
+                SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
+        verify(safeLogger).safeLogDocumentInformation(expectedModel, null, SAMPLE_ACCOUNT_ID, SAMPLE_SYSTEM_TAGS, logger);
+    }
+
+    // Test Update for True Update
+    @Test
+    public void testHandleRequest_withTrueUpdate_DocumentUpdateTagsSuccess_VerifyResponse() {
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .tags(SAMPLE_MODEL_TAGS)
+                .build();
+        final ResourceModel previousModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .tags(SAMPLE_PREVIOUS_MODEL_TAGS)
+                .build();
+
         final CallbackContext expectedCallbackContext = CallbackContext.builder().build();
 
-        final ProgressEvent<ResourceModel, CallbackContext> expectedResponse = ProgressEvent.failed(
-                expectedModel,
-                expectedCallbackContext,
-                HandlerErrorCode.NotUpdatable, "Create-Only Property cannot be updated");
+        final ProgressEvent<ResourceModel, CallbackContext> expectedResponse = ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModel(expectedModel)
+                .status(OperationStatus.SUCCESS)
+                .callbackContext(expectedCallbackContext)
+                .callbackDelaySeconds(0)
+                .build();       
 
-        final ProgressEvent<ResourceModel, CallbackContext> response
-                = unitUnderTest.handleRequest(proxy, SAMPLE_RESOURCE_HANDLER_INVALID_REQUEST, null, logger);
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(previousModel, expectedModel);
+        final ProgressEvent<ResourceModel, CallbackContext> response = unitUnderTest.handleRequest(proxy, request, null, logger);
+
+        Assertions.assertEquals(expectedResponse, response);
+        Mockito.verify(tagUpdater).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS, SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
+                SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
+        verify(safeLogger).safeLogDocumentInformation(expectedModel, null, SAMPLE_ACCOUNT_ID, SAMPLE_SYSTEM_TAGS, logger);
+    }
+
+    @Test
+    public void testHandleRequest_withTrueUpdate_DocumentUpdateTagsThrowsException_VerifyResponse() {
+        doThrow(ssmException).when(tagUpdater).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS,
+                SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS, SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
+
+        when(exceptionTranslator.getCfnException(ssmException, SAMPLE_DOCUMENT_NAME, OPERATION_NAME, logger)).thenReturn(cfnException);
+
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .tags(SAMPLE_MODEL_TAGS)
+                .build();
+        final ResourceModel previousModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .tags(SAMPLE_PREVIOUS_MODEL_TAGS)
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(previousModel, expectedModel);
+
+        Assertions.assertThrows(CfnGeneralServiceException.class, () -> unitUnderTest.handleRequest(proxy, request, null, logger));
+        verify(safeLogger).safeLogDocumentInformation(expectedModel, null, SAMPLE_ACCOUNT_ID, SAMPLE_SYSTEM_TAGS, logger);
+    }
+
+    @Test
+    public void testHandleRequest_withTrueUpdate_DocumentUpdateInProgress_VerifyResponse() {
+        // the name of the previousModel should be used automatically
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .content(SAMPLE_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .tags(SAMPLE_MODEL_TAGS)
+                .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .tags(SAMPLE_MODEL_TAGS)
+                .build();
+
+        final CallbackContext expectedCallbackContext = CallbackContext.builder()
+                .eventStarted(true)
+                .stabilizationRetriesRemaining(NUMBER_OF_DOCUMENT_UPDATE_POLL_RETRIES)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> expectedResponse = ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModel(expectedModel)
+                .status(OperationStatus.IN_PROGRESS)
+                .callbackContext(expectedCallbackContext)
+                .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
+                .message(IN_PROGRESS_MESSAGE)
+                .build();
+        
+        final UpdateDocumentResponse expectedUpdateDocumentResponse = UpdateDocumentResponse.builder()
+                .documentDescription(DocumentDescription.builder().name(SAMPLE_DOCUMENT_NAME).status(DocumentStatus.UPDATING).build())
+                .build();
+        when(proxy.injectCredentialsAndInvokeV2(any(UpdateDocumentRequest.class), any())).thenReturn(expectedUpdateDocumentResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(previousModel, expectedModel);
+        final ProgressEvent<ResourceModel, CallbackContext> response = unitUnderTest.handleRequest(proxy, request, null, logger);
 
         Assertions.assertEquals(expectedResponse, response);
         Mockito.verify(tagUpdater, never()).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS, SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
                 SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
-        verify(safeLogger).safeLogDocumentInformation(SAMPLE_INVALID_RESOURCE_MODEL, null, SAMPLE_ACCOUNT_ID, SAMPLE_SYSTEM_TAGS, logger);
+        verify(safeLogger).safeLogDocumentInformation(expectedModel, null, SAMPLE_ACCOUNT_ID, SAMPLE_SYSTEM_TAGS, logger);
+    }
+
+    @Test
+    public void testHandleRequest_withTrueUpdate_DocumentUpdateContentThrowsDuplicatedContentException_VerifyException() {
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .versionName("v2")
+                .tags(SAMPLE_MODEL_TAGS)
+                .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .versionName("v1")
+                .tags(SAMPLE_MODEL_TAGS)
+                .build();
+
+        final CallbackContext expectedCallbackContext = CallbackContext.builder()
+                .eventStarted(true)
+                .stabilizationRetriesRemaining(NUMBER_OF_DOCUMENT_UPDATE_POLL_RETRIES)
+                .build();
+        final ProgressEvent<ResourceModel, CallbackContext> expectedResponse = ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModel(expectedModel)
+                .status(OperationStatus.IN_PROGRESS)
+                .message(IN_PROGRESS_MESSAGE)
+                .callbackContext(expectedCallbackContext)
+                .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
+                .build();
+
+        when(proxy.injectCredentialsAndInvokeV2(any(UpdateDocumentRequest.class), any())).thenThrow(DuplicateDocumentContentException.class);
+        when(exceptionTranslator.getCfnException(any(DuplicateDocumentContentException.class), eq(SAMPLE_DOCUMENT_NAME), eq(OPERATION_NAME), eq(logger))).thenThrow(CfnInvalidRequestException.class);
+
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(previousModel, expectedModel);
+        
+        Assertions.assertThrows(CfnInvalidRequestException.class, () -> unitUnderTest.handleRequest(proxy, request, null, logger));
+        Mockito.verify(tagUpdater, never()).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS, SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
+                SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
+        verify(safeLogger).safeLogDocumentInformation(expectedModel, null, SAMPLE_ACCOUNT_ID, SAMPLE_SYSTEM_TAGS, logger);
+    }
+    
+    @Test
+    public void testHandleRequest_withTrueUpdate_DocumentUpdateNameThrowsException_VerifyException() {
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .name("newName")
+                .content(SAMPLE_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .tags(SAMPLE_MODEL_TAGS)
+                .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .tags(SAMPLE_MODEL_TAGS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(previousModel, expectedModel);
+
+        Assertions.assertThrows(CfnInvalidRequestException.class, () -> unitUnderTest.handleRequest(proxy, request, null, logger));
+        Mockito.verify(tagUpdater, never()).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS, SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
+                SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
+        verify(safeLogger).safeLogDocumentInformation(expectedModel, null, SAMPLE_ACCOUNT_ID, SAMPLE_SYSTEM_TAGS, logger);
+    }
+
+    @Test
+    public void testHandleRequest_withTrueUpdate_DocumentUpdateDocumentTypeThrowsException_VerifyException() {
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .tags(SAMPLE_MODEL_TAGS)
+                .documentType("Automation")
+                .build();
+
+        final ResourceModel previousModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .tags(SAMPLE_MODEL_TAGS)
+                .documentType("Command")
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(previousModel, expectedModel);
+
+        Assertions.assertThrows(CfnInvalidRequestException.class, () -> unitUnderTest.handleRequest(proxy, request, null, logger));
+        Mockito.verify(tagUpdater, never()).updateTags(SAMPLE_DOCUMENT_NAME, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS, SAMPLE_DESIRED_RESOURCE_TAGS, SAMPLE_PREVIOUS_MODEL_TAGS,
+                SAMPLE_MODEL_TAGS, ssmClient, proxy, logger);
+        verify(safeLogger).safeLogDocumentInformation(expectedModel, null, SAMPLE_ACCOUNT_ID, SAMPLE_SYSTEM_TAGS, logger);
+    }
+
+    // tests for True Update API call stablization 
+    @Test
+    public void testHandleRequest_withTrueUpdate_StabilizationRetrieverReturnsUpdatingStatus_VerifyResponse() {
+        final CallbackContext inProgressCallbackContext = CallbackContext.builder()
+                .eventStarted(true)
+                .stabilizationRetriesRemaining(NUMBER_OF_DOCUMENT_UPDATE_POLL_RETRIES)
+                .build();
+ 
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .build();
+        final ResourceModel previousModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .build();
+
+        final ResourceInformation expectedResourceInformation = ResourceInformation.builder().resourceModel(expectedModel)
+                .status(RESOURCE_MODEL_UPDATING_STATE)
+                .statusInformation(SAMPLE_STATUS_INFO)
+                .build();
+        final CallbackContext expectedCallbackContext = CallbackContext.builder()
+                .eventStarted(true)
+                .stabilizationRetriesRemaining(NUMBER_OF_DOCUMENT_UPDATE_POLL_RETRIES-1)
+                .build();
+        final GetProgressResponse getProgressResponse = GetProgressResponse.builder()
+                .callbackContext(expectedCallbackContext)
+                .resourceInformation(expectedResourceInformation)
+                .build();
+ 
+        final ProgressEvent<ResourceModel, CallbackContext> expectedResponse = ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModel(expectedModel)
+                .status(OperationStatus.IN_PROGRESS)
+                .message(SAMPLE_STATUS_INFO)
+                .callbackContext(expectedCallbackContext)
+                .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
+                .build();
+ 
+        when(progressUpdater.getEventProgress(expectedModel, inProgressCallbackContext, ssmClient, proxy, logger))
+                .thenReturn(getProgressResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(previousModel, expectedModel);
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = unitUnderTest.handleRequest(proxy, request, inProgressCallbackContext, logger);
+ 
+        Assertions.assertEquals(expectedResponse, response);
+    }
+
+    @Test
+    public void testHandleRequest_withTrueUpdate_StabilizationRetrieverReturnsActiveStatus_VerifyResponse() {
+        final CallbackContext inProgressCallbackContext = CallbackContext.builder()
+                .eventStarted(true)
+                .stabilizationRetriesRemaining(NUMBER_OF_DOCUMENT_UPDATE_POLL_RETRIES)
+                .build();
+ 
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .build();
+        final ResourceModel previousModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .build();
+
+        final ResourceInformation expectedResourceInformation = ResourceInformation.builder().resourceModel(expectedModel)
+                .status(RESOURCE_MODEL_ACTIVE_STATE)
+                .statusInformation(SAMPLE_STATUS_INFO)
+                .build();
+        final CallbackContext expectedCallbackContext = CallbackContext.builder()
+                .eventStarted(true)
+                .stabilizationRetriesRemaining(NUMBER_OF_DOCUMENT_UPDATE_POLL_RETRIES-1)
+                .build();
+        final GetProgressResponse getProgressResponse = GetProgressResponse.builder()
+                .callbackContext(expectedCallbackContext)
+                .resourceInformation(expectedResourceInformation)
+                .build();
+ 
+        final ProgressEvent<ResourceModel, CallbackContext> expectedResponse = ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModel(expectedModel)
+                .status(OperationStatus.SUCCESS)
+                .message(SAMPLE_STATUS_INFO)
+                .callbackContext(expectedCallbackContext)
+                .build();
+
+        final String defaultVersion = "1";
+        final String latestVersion = "2";
+        final DescribeDocumentResponse expectedDescribeDocumentResponse = DescribeDocumentResponse.builder()
+                .document(DocumentDescription.builder().name(SAMPLE_DOCUMENT_NAME).latestVersion(latestVersion).defaultVersion(defaultVersion).build())
+                .build();
+        final UpdateDocumentDefaultVersionRequest expectedUpdateDocumentDefaultVersionRequest = UpdateDocumentDefaultVersionRequest.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .documentVersion(latestVersion)
+                .build();
+
+        when(progressUpdater.getEventProgress(expectedModel, inProgressCallbackContext, ssmClient, proxy, logger))
+                .thenReturn(getProgressResponse);
+        when(proxy.injectCredentialsAndInvokeV2(any(DescribeDocumentRequest.class), any()))
+                .thenReturn(expectedDescribeDocumentResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(previousModel, expectedModel);
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = unitUnderTest.handleRequest(proxy, request, inProgressCallbackContext, logger);
+
+        Mockito.verify(proxy).injectCredentialsAndInvokeV2(eq(expectedUpdateDocumentDefaultVersionRequest), any());
+        Assertions.assertEquals(expectedResponse, response);
+    }
+
+    @Test
+    public void testHandleRequest_withTrueUpdate_StabilizationRetrieverReturnsFailedStatus_VerifyResponse() {
+        final CallbackContext inProgressCallbackContext = CallbackContext.builder()
+                .eventStarted(true)
+                .stabilizationRetriesRemaining(NUMBER_OF_DOCUMENT_UPDATE_POLL_RETRIES)
+                .build();
+ 
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .build();
+        final ResourceModel previousModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .build();
+
+        final ResourceInformation expectedResourceInformation = ResourceInformation.builder().resourceModel(expectedModel)
+                .status(RESOURCE_MODEL_FAILED_STATE)
+                .statusInformation(SAMPLE_STATUS_INFO)
+                .build();
+        final CallbackContext expectedCallbackContext = CallbackContext.builder()
+                .eventStarted(true)
+                .stabilizationRetriesRemaining(NUMBER_OF_DOCUMENT_UPDATE_POLL_RETRIES-1)
+                .build();
+        final GetProgressResponse getProgressResponse = GetProgressResponse.builder()
+                .callbackContext(expectedCallbackContext)
+                .resourceInformation(expectedResourceInformation)
+                .build();
+ 
+        final ProgressEvent<ResourceModel, CallbackContext> expectedResponse = ProgressEvent.<ResourceModel, CallbackContext>builder()
+                .resourceModel(expectedModel)
+                .status(OperationStatus.FAILED)
+                .message(SAMPLE_STATUS_INFO)
+                .callbackContext(expectedCallbackContext)
+                .callbackDelaySeconds(CALLBACK_DELAY_SECONDS)
+                .build();
+ 
+        when(progressUpdater.getEventProgress(expectedModel, inProgressCallbackContext, ssmClient, proxy, logger))
+                .thenReturn(getProgressResponse);
+
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(previousModel, expectedModel);
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = unitUnderTest.handleRequest(proxy, request, inProgressCallbackContext, logger);
+ 
+        Assertions.assertEquals(expectedResponse, response);
+    }
+
+    @Test
+    public void testHandleRequest_withTrueUpdate_StabilizationRetrieverThrowsException_VerifyException() {
+        final CallbackContext inProgressCallbackContext = CallbackContext.builder()
+                .eventStarted(true)
+                .stabilizationRetriesRemaining(NUMBER_OF_DOCUMENT_UPDATE_POLL_RETRIES)
+                .build();
+        final ResourceModel expectedModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .build();
+        final ResourceModel previousModel = ResourceModel.builder()
+                .name(SAMPLE_DOCUMENT_NAME)
+                .content(SAMPLE_PREVIOUS_DOCUMENT_CONTENT)
+                .updateMethod(NEW_VERSION)
+                .build();
+ 
+        when(progressUpdater.getEventProgress(expectedModel, inProgressCallbackContext, ssmClient, proxy, logger))
+                .thenThrow(SsmException.class);
+        when(exceptionTranslator.getCfnException(any(SsmException.class), eq(SAMPLE_DOCUMENT_NAME), eq(OPERATION_NAME), eq(logger))).thenThrow(CfnGeneralServiceException.class);
+        
+        final ResourceHandlerRequest<ResourceModel> request = buildRequest(previousModel, expectedModel);
+        Assertions.assertThrows(CfnGeneralServiceException.class, () -> unitUnderTest.handleRequest(proxy, request, inProgressCallbackContext, logger));
+    }
+
+    private ResourceHandlerRequest<ResourceModel> buildRequest(ResourceModel previousModel, ResourceModel model) {
+        return buildRequest(previousModel, model, SAMPLE_PREVIOUS_DESIRED_RESOURCE_TAGS, SAMPLE_DESIRED_RESOURCE_TAGS);
+    }
+
+    private ResourceHandlerRequest<ResourceModel> buildRequest(ResourceModel previousModel, ResourceModel model, Map<String, String> previousTags, Map<String, String> tags) {
+        return ResourceHandlerRequest.<ResourceModel>builder()
+            .systemTags(SAMPLE_SYSTEM_TAGS)
+            .desiredResourceTags(tags)
+            .previousResourceTags(previousTags)
+            .clientRequestToken(SAMPLE_REQUEST_TOKEN)
+            .desiredResourceState(model)
+            .previousResourceState(previousModel)
+            .awsAccountId(SAMPLE_ACCOUNT_ID)
+            .build();
     }
 }


### PR DESCRIPTION
*Description of changes:* add support for updating AWS::SSM::Document with new versions
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
