### PR TITLE
Fix UpdateProgress operation status translate in UpdateHandler

### DIFF
--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/UpdateHandler.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/UpdateHandler.java
@@ -201,6 +201,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         switch (status) {
             case ACTIVE:
                 return OperationStatus.SUCCESS;
+            case CREATING:
             case UPDATING:
                 return OperationStatus.IN_PROGRESS;
             default:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,8 +6,7 @@ phases:
       python: 3.7
     commands:
       - pip install --upgrade 'six==1.16.0'
-      - pip install --upgrade 'docker==4.2.0'
-      - pip install --upgrade 'virtualenv==20.0.18'
+      - pip install --upgrade 'requests>=2.26.0'
       - pip install pre-commit cloudformation-cli-java-plugin
       - pip install pyyaml --upgrade
       - pip install boto3 --upgrade

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,8 @@ phases:
       python: 3.7
     commands:
       - pip install --upgrade 'six==1.16.0'
+      - pip install --upgrade 'docker==4.2.0'
+      - pip install --upgrade 'virtualenv==20.0.18'
       - pip install pre-commit cloudformation-cli-java-plugin
       - pip install pyyaml --upgrade
       - pip install boto3 --upgrade


### PR DESCRIPTION
*Issue #, if available:* N/A, Customer reported issue

*Description of changes:* This change is to fix the Operation status translate issue in UpdateHandler, when attachments available in UpdateDocument request, the status for document is *Creating*, this status is not correctly captured in status handle logic, which causing the update process falsely failed.

Added `requests` package version requirement to resolve build issue.

#### Test
Tested with customer CFN register handler. `cfn submit --set-default --region us-east-1  --no-role`.

