### PR TITLE
Fix the tagging metadata in document and remove tagging in resourceda…

### DIFF
--- a/aws-ssm-document/aws-ssm-document.json
+++ b/aws-ssm-document/aws-ssm-document.json
@@ -177,6 +177,9 @@
     "primaryIdentifier": [
         "/properties/Name"
     ],
+    "tagging": {
+        "taggable": true
+    },
     "handlers": {
         "create": {
             "permissions": [

--- a/aws-ssm-resourcedatasync/aws-ssm-resourcedatasync.json
+++ b/aws-ssm-resourcedatasync/aws-ssm-resourcedatasync.json
@@ -151,9 +151,6 @@
     "readOnlyProperties": [
         "/properties/SyncName"
     ],
-    "tagging": {
-        "taggable": "true"
-    },
     "handlers": {
         "create": {
             "permissions": [


### PR DESCRIPTION
…tasync

*Issue #, if available:* 
N/A

*Description of changes:* 

Fix for the tagging metadata mis config introduced by [PR #194](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-ssm/pull/194). 

Tagging was added in aws-ssm-resourcedatasync.json, but should be in aws-ssm-document.json


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
