### PR TITLE
AWS::SSM::Document retrieve tag info during stabilization from describeDocument instead …

### DIFF
--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
@@ -42,14 +42,13 @@ class DocumentResponseModelTranslator {
                 .build();
     }
 
-    ResourceInformation generateResourceInformation(@NonNull final DescribeDocumentResponse response,
-                                                    @NonNull final Map<String, String> documentTagMap) {
+    ResourceInformation generateResourceInformation(@NonNull final DescribeDocumentResponse response) {
         final ResourceModel model = ResourceModel.builder()
                 .name(response.document().name())
                 .versionName(response.document().versionName())
                 .documentFormat(response.document().documentFormatAsString())
                 .documentType(response.document().documentTypeAsString())
-                .tags(translateToResourceModelTags(documentTagMap))
+                .tags(translateTags(response.document().tags()))
                 .requires(translateRequires(response))
                 .targetType(response.document().targetType())
                 .build();
@@ -119,5 +118,14 @@ class DocumentResponseModelTranslator {
                         .version(documentRequires.version())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    private List<Tag> translateTags(final List<software.amazon.awssdk.services.ssm.model.Tag> tags) {
+        return tags.stream().map(
+            tag -> Tag.builder()
+                .key(tag.key())
+                .value(tag.value())
+                .build())
+            .collect(Collectors.toList());
     }
 }

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/DocumentResponseModelTranslator.java
@@ -48,7 +48,7 @@ class DocumentResponseModelTranslator {
                 .versionName(response.document().versionName())
                 .documentFormat(response.document().documentFormatAsString())
                 .documentType(response.document().documentTypeAsString())
-                .tags(translateTags(response.document().tags()))
+                .tags(translateDocumentTagsToResourceModelTags(response.document().tags()))
                 .requires(translateRequires(response))
                 .targetType(response.document().targetType())
                 .build();
@@ -90,6 +90,15 @@ class DocumentResponseModelTranslator {
             .collect(Collectors.toList());
     }
 
+    private List<Tag> translateDocumentTagsToResourceModelTags(final List<software.amazon.awssdk.services.ssm.model.Tag> tags) {
+        return tags.stream().map(
+            tag -> Tag.builder()
+                .key(tag.key())
+                .value(tag.value())
+                .build())
+            .collect(Collectors.toList());
+    }
+
     private List<DocumentRequires> translateRequires(final GetDocumentResponse response) {
         if (!response.hasRequires()) {
             return null;
@@ -118,14 +127,5 @@ class DocumentResponseModelTranslator {
                         .version(documentRequires.version())
                         .build())
                 .collect(Collectors.toList());
-    }
-
-    private List<Tag> translateTags(final List<software.amazon.awssdk.services.ssm.model.Tag> tags) {
-        return tags.stream().map(
-            tag -> Tag.builder()
-                .key(tag.key())
-                .value(tag.value())
-                .build())
-            .collect(Collectors.toList());
     }
 }

--- a/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/StabilizationProgressRetriever.java
+++ b/aws-ssm-document/src/main/java/com/amazonaws/ssm/document/StabilizationProgressRetriever.java
@@ -82,10 +82,8 @@ class StabilizationProgressRetriever {
             return getEventProgressWithGetDocument(model, context, ssmClient, proxy);
         }
 
-        final Map<String, String> documentTags = tagReader.getDocumentTags(model.getName(), ssmClient, proxy);
-
         final ResourceInformation resourceInformation =
-                documentResponseModelTranslator.generateResourceInformation(describeResponse, documentTags);
+                documentResponseModelTranslator.generateResourceInformation(describeResponse);
 
         return GetProgressResponse.builder()
                 .resourceInformation(resourceInformation)

--- a/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentResponseModelTranslatorTest.java
+++ b/aws-ssm-document/src/test/java/com/amazonaws/ssm/document/DocumentResponseModelTranslatorTest.java
@@ -21,6 +21,10 @@ public class DocumentResponseModelTranslatorTest {
     private static final String SAMPLE_DOCUMENT_TYPE = "Command";
     private static final String SAMPLE_DOCUMENT_VERSION = "3";
     private static final String SAMPLE_TARGET_TYPE = "targetType";
+    private static final List<software.amazon.awssdk.services.ssm.model.Tag> SAMPLE_TAGS = ImmutableList.of(
+        software.amazon.awssdk.services.ssm.model.Tag.builder().key("tagKey1").value("tagValue1").build(),
+        software.amazon.awssdk.services.ssm.model.Tag.builder().key("tagKey2").value("tagValue2").build()
+    );
     private static final List<Tag> SAMPLE_RESOURCE_MODEL_TAGS = ImmutableList.of(
             Tag.builder().key("tagKey1").value("tagValue1").build(),
             Tag.builder().key("tagKey2").value("tagValue2").build()
@@ -102,7 +106,7 @@ public class DocumentResponseModelTranslatorTest {
         final DescribeDocumentResponse describeDocumentResponse = createDescribeDocumentResponseWithAllAttributes();
 
         final ResourceInformation resourceInformation =
-                unitUnderTest.generateResourceInformation(describeDocumentResponse, SAMPLE_TAG_MAP);
+                unitUnderTest.generateResourceInformation(describeDocumentResponse);
 
         Assertions.assertEquals(expectedResourceInformation, resourceInformation);
     }
@@ -232,6 +236,7 @@ public class DocumentResponseModelTranslatorTest {
                         .documentFormat(SAMPLE_DOCUMENT_FORMAT)
                         .attachmentsInformation(SAMPLE_DESCRIBE_RESPONSE_ATTACHMENTS)
                         .requires(SAMPLE_GET_RESPONSE_REQUIRES)
+                        .tags(SAMPLE_TAGS)
                         .build())
                 .build();
     }


### PR DESCRIPTION
…of tag apis

*Issue #, if available:* N/A

*Description of changes:*
retrieve tag info during stabilization from describeDocument instead of tag apis


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
