### PR TITLE
Migrate contract tests to V2

### DIFF
--- a/aws-ssm-association/aws-ssm-association.json
+++ b/aws-ssm-association/aws-ssm-association.json
@@ -219,6 +219,9 @@
     "readOnlyProperties": [
         "/properties/AssociationId"
     ],
+    "writeOnlyProperties": [
+        "/properties/WaitForSuccessTimeoutSeconds"
+    ],
     "primaryIdentifier": [
         "/properties/AssociationId"
     ],
@@ -231,7 +234,8 @@
                 "ec2:DescribeInstanceStatus",
                 "iam:PassRole",
                 "ssm:CreateAssociation",
-                "ssm:DescribeAssociation"
+                "ssm:DescribeAssociation",
+                "ssm:GetCalendarState"
             ]
         },
         "delete": {
@@ -242,7 +246,8 @@
         "update": {
             "permissions": [
                 "iam:PassRole",
-                "ssm:UpdateAssociation"
+                "ssm:UpdateAssociation",
+                "ssm:GetCalendarState"
             ]
         },
         "read": {

--- a/aws-ssm-association/contract-tests-artifacts/dependencies.yml
+++ b/aws-ssm-association/contract-tests-artifacts/dependencies.yml
@@ -1,0 +1,58 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  LatestAmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+Resources:
+  Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref 'LatestAmiId'
+      InstanceType: t3.small
+  ContractTestS3OutputBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: BucketOwnerFullControl
+      BucketName: !Sub ssm-association-cfn-contract-test-${AWS::AccountId}
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Enabled
+  DefaultOpenChangeCalendarDocument:
+    Type: 'AWS::SSM::Document'
+    Properties:
+      Content: "BEGIN:VCALENDAR\r\nPRODID:-//AWS//Change Calendar 1.0//EN\r\nVERSION:2.0\r\nX-CALENDAR-TYPE:DEFAULT_OPEN\r\nX-WR-CALDESC:test\r\nBEGIN:VTODO\r\nDTSTAMP:20200320T004207Z\r\nUID:3b5af39a-d0b3-4049-a839-d7bb8af01f92\r\nSUMMARY:Add events to this calendar.\r\nEND:VTODO\r\nEND:VCALENDAR\r\n"
+      DocumentType: ChangeCalendar
+      DocumentFormat: TEXT
+  UpdatePackagesDocument:
+    Type: AWS::SSM::Document
+    Properties:
+      Content:
+        mainSteps:
+          - "action": "aws:runShellScript"
+            "name": "UpdatePackages"
+            "inputs":
+              "runCommand":
+                - "yum update -y"
+        parameters: {}
+        schemaVersion: "2.0"
+      DocumentType: "Command"
+Outputs:
+  InstanceId:
+    Value: !Ref Instance
+    Export:
+      Name: awsssmassociationcto1
+  ContractTestBucketName:
+    Value: !Ref ContractTestS3OutputBucket
+    Export:
+      Name: awsssmassociationcto2
+  CalendarName:
+    Value: !Ref DefaultOpenChangeCalendarDocument
+    Export:
+      Name: awsssmassociationcto3
+  DocumentName:
+    Value: !Ref UpdatePackagesDocument
+    Export:
+      Name: awsssmassociationcto4

--- a/aws-ssm-association/contract-tests-artifacts/inputs_1.json
+++ b/aws-ssm-association/contract-tests-artifacts/inputs_1.json
@@ -1,0 +1,41 @@
+{
+    "CreateInputs": {
+        "AssociationName": "test1",
+        "Name": "AWS-RunShellScript",
+        "ComplianceSeverity": "HIGH",
+        "SyncCompliance": "AUTO",
+        "WaitForSuccessTimeoutSeconds": 60,
+        "Targets": [
+            {
+                "Key": "InstanceIds",
+                "Values": [
+                    "*"
+                ]
+            }
+        ],
+        "Parameters": {
+            "commands": [
+                "ls"
+            ],
+            "workingDirectory": [
+                "/"
+            ]
+        },
+        "MaxConcurrency": "50%",
+        "MaxErrors": "5%",
+        "OutputLocation": {
+            "S3Location": {
+                "OutputS3BucketName": "{{awsssmassociationcto2}}",
+                "OutputS3KeyPrefix": "outputs",
+                "OutputS3Region": "{{ region }}"
+            }
+        }
+    },
+    "PatchInputs": [
+        {
+            "op": "replace",
+            "path": "/MaxConcurrency",
+            "value": "100%"
+        }
+    ]
+}

--- a/aws-ssm-association/contract-tests-artifacts/inputs_2.json
+++ b/aws-ssm-association/contract-tests-artifacts/inputs_2.json
@@ -1,0 +1,15 @@
+{
+    "CreateInputs": {
+        "Name": "AWS-RunShellScript",
+        "InstanceId": "{{ awsssmassociationcto1 }}",
+        "Parameters": {
+            "commands": [
+                "ls"
+            ],
+            "workingDirectory": [
+                "/"
+            ]
+        }
+    },
+    "PatchInputs": []
+}

--- a/aws-ssm-association/contract-tests-artifacts/inputs_3.json
+++ b/aws-ssm-association/contract-tests-artifacts/inputs_3.json
@@ -1,0 +1,26 @@
+{
+    "CreateInputs": {
+        "Name": "AWS-EnableS3BucketEncryption",
+        "AutomationTargetParameterName": "BucketName",
+        "ScheduleExpression": "cron(28 21 ? * TUE#2 *)",
+        "ScheduleOffset": 3,
+        "ApplyOnlyAtCronInterval": true,
+        "CalendarNames": [
+            "{{awsssmassociationcto3}}"
+        ],
+        "Targets": [
+            {
+                "Key": "ParameterValues",
+                "Values": [
+                    "bucket"
+                ]
+            }
+        ],
+        "Parameters": {
+            "AutomationAssumeRole": [
+                "arn:aws:iam::{{account}}:role/ReadOnly"
+            ]
+        }
+    },
+    "PatchInputs": []
+}

--- a/aws-ssm-association/contract-tests-artifacts/inputs_4.json
+++ b/aws-ssm-association/contract-tests-artifacts/inputs_4.json
@@ -1,0 +1,15 @@
+{
+    "CreateInputs": {
+        "Name": "{{awsssmassociationcto4}}",
+        "DocumentVersion": "$DEFAULT",
+        "Targets": [
+            {
+                "Key": "InstanceIds",
+                "Values": [
+                    "*"
+                ]
+            }
+        ]
+    },
+    "PatchInputs": []
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Migrate contract tests to V2

Add GetCalendarState permission when creating/updating association with calendarNames.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
