### PR TITLE
adding duration parameter to the AWS::SSM::Association resource

### DIFF
--- a/aws-ssm-association/aws-ssm-association.json
+++ b/aws-ssm-association/aws-ssm-association.json
@@ -211,6 +211,11 @@
             "type": "integer",
             "minimum": 1,
             "maximum": 6
+        },
+        "Duration": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 24
         }
     },
     "required": [

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/AssociationDescriptionTranslator.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/AssociationDescriptionTranslator.java
@@ -96,6 +96,9 @@ public class AssociationDescriptionTranslator {
         simpleTypeValidator.getValidatedInteger(association.scheduleOffset())
             .ifPresent(model::setScheduleOffset);
 
+        simpleTypeValidator.getValidatedInteger(association.duration())
+            .ifPresent(model::setDuration);
+
         return model;
     }
 }

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/request/CreateAssociationTranslator.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/request/CreateAssociationTranslator.java
@@ -94,6 +94,9 @@ public class CreateAssociationTranslator implements RequestTranslator<CreateAsso
         simpleTypeValidator.getValidatedInteger(model.getScheduleOffset())
             .ifPresent(createAssociationRequestBuilder::scheduleOffset);
 
+        simpleTypeValidator.getValidatedInteger(association.getDuration())
+            .ifPresent(createAssociationRequestBuilder::duration);
+
         return createAssociationRequestBuilder.build();
     }
 }

--- a/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/request/UpdateAssociationTranslator.java
+++ b/aws-ssm-association/src/main/java/com/amazonaws/ssm/association/translator/request/UpdateAssociationTranslator.java
@@ -94,6 +94,9 @@ public class UpdateAssociationTranslator implements RequestTranslator<UpdateAsso
         simpleTypeValidator.getValidatedInteger(model.getScheduleOffset())
             .ifPresent(updateAssociationRequestBuilder::scheduleOffset);
 
+        simpleTypeValidator.getValidatedInteger(model.getDuration())
+            .ifPresent(updateAssociationRequestBuilder::duration);
+
         return updateAssociationRequestBuilder.build();
     }
 }

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/TestsInputs.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/TestsInputs.java
@@ -76,4 +76,6 @@ public class TestsInputs {
     );
 
     public static final Integer SCHEDULE_OFFSET = 2;
+
+    public static final Integer CUTOFF_DURATION = 4;
 }

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/AssociationDescriptionTranslatorTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/AssociationDescriptionTranslatorTest.java
@@ -34,6 +34,7 @@ import static com.amazonaws.ssm.association.TestsInputs.MODEL_TARGETS;
 import static com.amazonaws.ssm.association.TestsInputs.PARAMETERS;
 import static com.amazonaws.ssm.association.TestsInputs.SCHEDULE_EXPRESSION;
 import static com.amazonaws.ssm.association.TestsInputs.SCHEDULE_OFFSET;
+import static com.amazonaws.ssm.association.TestsInputs.CUTOFF_DURATION;
 import static com.amazonaws.ssm.association.TestsInputs.SERVICE_OUTPUT_LOCATION;
 import static com.amazonaws.ssm.association.TestsInputs.SERVICE_TARGETS;
 import static com.amazonaws.ssm.association.TestsInputs.SYNC_COMPLIANCE;
@@ -93,6 +94,7 @@ class AssociationDescriptionTranslatorTest {
                 .applyOnlyAtCronInterval(true)
                 .calendarNames(CALENDAR_NAMES)
                 .scheduleOffset(SCHEDULE_OFFSET)
+                .duration(CUTOFF_DURATION)
                 .build();
 
         final ResourceModel resultModel =
@@ -117,6 +119,7 @@ class AssociationDescriptionTranslatorTest {
                 .applyOnlyAtCronInterval(true)
                 .calendarNames(CALENDAR_NAMES)
                 .scheduleOffset(SCHEDULE_OFFSET)
+                .duration(CUTOFF_DURATION)
                 .build();
 
         assertThat(resultModel).isEqualTo(expectedModel);

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/request/CreateAssociationTranslatorTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/request/CreateAssociationTranslatorTest.java
@@ -28,6 +28,7 @@ import static com.amazonaws.ssm.association.TestsInputs.MODEL_TARGETS;
 import static com.amazonaws.ssm.association.TestsInputs.PARAMETERS;
 import static com.amazonaws.ssm.association.TestsInputs.SCHEDULE_EXPRESSION;
 import static com.amazonaws.ssm.association.TestsInputs.SCHEDULE_OFFSET;
+import static com.amazonaws.ssm.association.TestsInputs.CUTOFF_DURATION;
 import static com.amazonaws.ssm.association.TestsInputs.SERVICE_OUTPUT_LOCATION;
 import static com.amazonaws.ssm.association.TestsInputs.SERVICE_TARGETS;
 import static com.amazonaws.ssm.association.TestsInputs.SYNC_COMPLIANCE;
@@ -82,6 +83,7 @@ class CreateAssociationTranslatorTest {
                 .applyOnlyAtCronInterval(true)
                 .calendarNames(CALENDAR_NAMES)
                 .scheduleOffset(SCHEDULE_OFFSET)
+                .duration(CUTOFF_DURATION)
                 .build();
 
         final CreateAssociationRequest createAssociationRequest =
@@ -105,6 +107,7 @@ class CreateAssociationTranslatorTest {
                 .applyOnlyAtCronInterval(true)
                 .calendarNames(CALENDAR_NAMES)
                 .scheduleOffset(SCHEDULE_OFFSET)
+                .duration(CUTOFF_DURATION)
                 .build();
 
         assertThat(createAssociationRequest).isEqualTo(expectedRequest);

--- a/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/request/UpdateAssociationTranslatorTest.java
+++ b/aws-ssm-association/src/test/java/com/amazonaws/ssm/association/translator/request/UpdateAssociationTranslatorTest.java
@@ -27,6 +27,7 @@ import static com.amazonaws.ssm.association.TestsInputs.MODEL_TARGETS;
 import static com.amazonaws.ssm.association.TestsInputs.PARAMETERS;
 import static com.amazonaws.ssm.association.TestsInputs.SCHEDULE_EXPRESSION;
 import static com.amazonaws.ssm.association.TestsInputs.SCHEDULE_OFFSET;
+import static com.amazonaws.ssm.association.TestsInputs.CUTOFF_DURATION;
 import static com.amazonaws.ssm.association.TestsInputs.SERVICE_OUTPUT_LOCATION;
 import static com.amazonaws.ssm.association.TestsInputs.SERVICE_TARGETS;
 import static com.amazonaws.ssm.association.TestsInputs.SYNC_COMPLIANCE;
@@ -81,6 +82,7 @@ class UpdateAssociationTranslatorTest {
                 .applyOnlyAtCronInterval(true)
                 .calendarNames(CALENDAR_NAMES)
                 .scheduleOffset(SCHEDULE_OFFSET)
+                .duration(CUTOFF_DURATION)
                 .build();
 
         final UpdateAssociationRequest createAssociationRequest =
@@ -104,6 +106,7 @@ class UpdateAssociationTranslatorTest {
                 .applyOnlyAtCronInterval(true)
                 .calendarNames(CALENDAR_NAMES)
                 .scheduleOffset(SCHEDULE_OFFSET)
+                .duration(CUTOFF_DURATION)
                 .build();
 
         assertThat(createAssociationRequest).isEqualTo(expectedRequest);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding the duration parameter to the association resource. This is part of the cutoff feature design


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
